### PR TITLE
initial implimentation of microsoft.network Service 

### DIFF
--- a/components/network/id.ftl
+++ b/components/network/id.ftl
@@ -1,0 +1,33 @@
+[#ftl]
+[@addResourceGroupInformation
+  type=NETWORK_COMPONENT_TYPE
+  attributes=[]
+  provider=AZURE_PROVIDER
+  resourceGroup=DEFAULT_RESOURCE_GROUP
+  services=
+    [
+      AZURE_NETWORK_SERVICE
+    ]
+/]
+
+[@addResourceGroupInformation
+  type=NETWORK_ACL_COMPONENT_TYPE
+  attributes=[]
+  provider=AZURE_PROVIDER
+  resourceGroup=DEFAULT_RESOURCE_GROUP
+  services=
+    [
+      AZURE_NETWORK_SERVICE
+    ]
+/]
+
+[@addResourceGroupInformation
+  type=NETWORK_ROUTE_TABLE_COMPONENT_TYPE
+  attributes=[]
+  provider=AZURE_PROVIDER
+  resourceGroup=DEFAULT_RESOURCE_GROUP
+  services=
+    [
+      AZURE_NETWORK_SERVICE
+    ]
+/]

--- a/components/network/setup.ftl
+++ b/components/network/setup.ftl
@@ -1,0 +1,252 @@
+[#ftl]
+
+[#macro azure_network_arm_segment occurrence]
+  [@debug message="Entering" context=occurrence enabled=false /]
+
+  [#if deploymentSubsetRequired("genplan", false)]
+      [@addDefaultGenerationPlan subsets="template" /]
+      [#return]
+  [/#if]
+
+  [#local core = occurrence.Core]
+  [#local solution = occurrence.Configuration.Solution]
+  [#local resources = occurrence.State.Resources]
+
+  [#local vnetId = resources["vnet"].Id]
+  [#local vnetName = resources["vnet"].Name]
+  [#local vnetCIDR = resources["vnet"].Address]
+
+  [#if deploymentSubsetRequired(NETWORK_COMPONENT_TYPE, true)]
+
+    [#-- 
+      Resource Order 
+        1. Vnet
+        2. NetworkSecurityGroup
+        3. Subnets for every tier & zone
+        . Subcomponents - per subOccurrence
+          4. Route Tables
+          5. NSG Rules
+        6. NetworkWatcher for FlowLogs
+    --]
+
+    [#-- 1. Vnet --]
+    [@createVNet
+      name=vnetName
+      location=regionId
+      addressSpacePrefixes=[vnetCIDR]
+    /]
+
+    [#-- 2. NetworkSecurityGroup + Default Rules --]
+    [#local networkSecurityGroupId = resources["networkSecurityGroup"].Id]
+    [#local networkSecurityGroupName = resources["networkSecurityGroup"].Name]
+
+    [@createNetworkSecurityGroup
+      name=networkSecurityGroupName
+      location=regionId
+    /]
+
+    [#-- Deny inbound/outbound access by default. 
+    To be overridden on applicable tiers by specific rules. --]
+
+    [@createNetworkSecurityGroupSecurityRule
+      name=formatName(networkSecurityGroupName, "DenyAllInbound")
+      description="Deny All Inbound"
+      protocol="*"
+      sourcePortRange="*"
+      destinationPortRange="*"
+      sourceAddressPrefix="0.0.0.0/0"
+      destinationAddressPrefix="0.0.0.0/0"
+      access="Deny"
+      priority="64999"
+      direction="Inbound"
+    /]
+
+    [@createNetworkSecurityGroupSecurityRule
+      name=formatName(networkSecurityGroupName, "DenyAllOutbound")
+      description="Deny All Outbound"
+      protocol="*"
+      sourcePortRange="*"
+      destinationPortRange="*"
+      sourceAddressPrefix="0.0.0.0/0"
+      destinationAddressPrefix="0.0.0.0/0"
+      access="Deny"
+      priority="64998"
+      direction="Outbound"
+    /]
+
+    [#-- 3. Subnets for every tier & zone --]
+    [#if (resources["subnets"]!{})?has_content]
+
+      [#local subnetResources = resources["subnets"]]
+      [#list subnetResources as tierId, zoneSubnets]
+
+        [#local networkTier = getTier(tierId)]
+        [#local tierNetwork = getTierNetwork(tierId)]
+        
+        [#local networkLink = tierNetwork.Link!{}]
+        [#local routeTableId = tierNetwork.RouteTable!""]
+        [#local networkACLId = tierNetwork.NetworkACL!""]
+
+        [#if !networkLink?has_content || !routeTableId?has_content || !networkACLId?has_content]
+          [@fatal
+            message="Tier Network configuration incomplete"
+            context=
+              tierNetwork +
+              {
+                "Link" : networkLink,
+                "RouteTable" : routeTableId,
+                "NetworkACL" : networkACLId
+              }
+          /]
+        [/#if]
+
+        [#local routeTable = getLinkTarget(occurrence, networkLink + { "RouteTable" : routeTableId }, false)]
+        [#local routeTableZones = routeTable.State.Resources["routeTables"]]
+
+        [#local networkACL = getLinkTarget(occurrence, networkLink + { "NetworkACL" : networkACLId }, false)]
+        [#local networkSecurityGroupZones = networkACL.State.Resources["networkSecurityGroups"]]
+
+        [#list zones as zone]
+
+          [#if zoneSubnets[zone.Id]?has_content]
+
+            [#local zoneSubnetResources = zoneSubnets[zone.Id]]
+            [#local subnetName = zoneSubnetResources["subnet"].Name]
+            [#local subnetAddress = zoneSubnetResources["subnet"].Address]
+            [#local routeTableId = (routeTableZones[zone.Id]["routeTable"]).Id]
+
+            [@createSubnet
+              name=subnetName
+              addressPrefix=subnetAddress
+              networkSecurityGroup={ "id" : networkSecurityGroupId }
+              routeTable= { "id" : routeTableId }     
+            /]
+
+          [/#if]
+        [/#list]
+      [/#list]
+    [/#if]
+
+    [#-- Sub Components --]
+    [#list occurrence.Occurrences![] as subOccurrence]
+
+      [#local core = subOccurrence.Core]
+      [#local solution = subOccurrence.Configuration.Solution]
+      [#local resources = subOccurrence.State.Resources]
+
+      [@debug message="Suboccurrence" context=subOccurrence enabled=false /]
+
+      [#-- 4. RouteTables --]
+      [#if core.Type == NETWORK_ROUTE_TABLE_COMPONENT_TYPE]
+
+        [#local zoneRouteTables = resources["routeTables"]]
+
+        [#list zones as zone]
+          [#if zoneRouteTables[zone.Id]?has_content]
+            [#local zoneRouteTableResources = zoneRouteTables[zone.Id]]
+            [#local routeTableName = zoneRouteTableResources["routeTable"].Name]
+
+            [@createRouteTable
+              name=routeTableName
+              location=zone.AzureId
+            /]
+
+          [/#if]
+        [/#list]
+      [/#if]
+
+      [#-- 5. Network Security Group Rules --]
+      [#if core.Type == NETWORK_ACL_COMPONENT_TYPE]
+        
+        [#local networkSecurityGroupRules = resources["rules"]]
+
+        [#list networkSecurityGroupRules as id, rule]
+
+          [#local ruleId = rule.Id]
+          [#local ruleConfig = solution.Rules[id]]
+          [#local ruleAction = ruleConfig.Action]
+
+          [#if (ruleConfig.Source.IPAddressGroups)?seq_contains("_localnet")
+            && (ruleConfig.Source.IPAddressGroups)?size == 1 ]
+
+            [#-- Port wildcards will be defined within COT by "any". Azure uses "*" --]
+            [#local direction = "Outbound" ]
+            [#local destinationIPAddresses = getGroupCIDRs(ruleConfig.Destination.IPAddressGroups, true, occurrence)]
+            [#local destinationPort = ports[ruleConfig.Destination.Port]]
+            [#local sourceIpAddresses = getGroupCIDRs(ruleConfig.Destination.IPAddressGroups, true, occurrence)]
+            [#local sourcePort = ports[ruleConfig.Source.Port]]
+
+          [#elseif (ruleConfig.Destination.IPAddressGroups)?seq_contains("_localnet")
+            && (ruleConfig.Source.IPAddressGroups)?size == 1 ]
+
+            [#local direction = "Inbound" ]
+            [#local destinationIPAddresses = getGroupCIDRs(ruleConfig.Source.IPAddressGroups, true, occurrence)]
+            [#local destinationPort = ports[ruleConfig.Destination.Port]]
+            [#local sourceIpAddresses = [ "0.0.0.0/0" ]]
+            [#local sourcePort = ports[ruleConfig.Destination.Port]]
+
+          [#else]
+            [@fatal
+                message="Invalid network ACL either source or destination must be configured as _local to define direction"
+                context=port
+            /]
+          [/#if]
+
+          [#-- NSG's are Stateful, so do not require rules for return traffic.
+          
+          Here we also make use of the ability to pass an array of source/destination
+          addresses to the same rule. --]
+          [#local ruleOrder = ruleConfig.Priority + ipAddress?index]
+          [#local description = rule.Action?cap_first + destinationIPAddresses?cap_first + direction?cap_first]
+
+          [@createNetworkSecurityGroupSecurityRule
+            name=formatId(ruleId,direction,ruleOrder)
+            description=description
+            protocol="*"
+            sourcePortRange=(sourcePort?replace("any","*"))
+            destinationPortRange=(destinationPort?replace("any","*"))
+            sourceAddressPrefixes=sourceIpAddresses
+            destinationAddressPrefixes=destinationIPAddresses
+            access=ruleAction
+            priority=ruleOrder
+            direction=direction
+          /]
+        [/#list]
+      [/#if]
+    [/#list]
+
+    [#-- TODO(rossmurr4y): Flow Logs object is not currently supported, though exists when created
+    via PowerShell. This is being developed by Microsoft and expected Jan 2020 - will need to revisit
+    this implimentation at that time to ensure this object remains correct.
+    https://feedback.azure.com/forums/217313-networking/suggestions/37713784-arm-template-support-for-nsg-flow-logs
+    --]
+    [#-- 6. NetworkWatcher : Flow Logs --]
+    [#if (resources["flowlogs"]!{})?has_content]
+      [#local flowLogResources = resources["flowlogs"]]
+      [#local flowLogNSGId = flowLogResources["networkWatcherFlowlog"].Id]
+
+      [#local flowLogStorageId = getReference(
+        formatResourceId(
+          AZURE_STORAGEACCOUNT_RESOURCE_TYPE,
+          core.Id
+        )
+      )]
+
+      [@createNetworkWatcherFlowLog
+        name=flowLogNSGId
+        targetResourceId=networkSecurityGroupId
+        storageId=flowLogStorageId
+        enabled=true
+        trafficAnalyticsInterval="0"
+        retentionPolicyEnabled=true
+        retentionDays="7"
+        formatType="JSON"
+        formatVersion="0"
+        dependsOn=
+          [
+            flowLogStorageId
+          ]
+      /]
+    [/#if]
+  [/#if]
+[/#macro]

--- a/components/network/state.ftl
+++ b/components/network/state.ftl
@@ -1,0 +1,199 @@
+[#ftl]
+
+[#macro azure_network_arm_state occurrence parent={} baseState={}]
+  
+  [#local core = occurrence.Core]
+  [#local solution = occurrence.Configuration.Solution]
+
+  [#local vnetId = formatVirtualNetworkId(core.Id)]
+  [#local vnetName = core.FullName]
+  [#local networkSecurityGroupId = formatDependentNetworkSecurityGroupId(vnetId)]
+  [#local nsgFlowlogId = formatDependentNetworkWatcherId(networkSecurityGroupId)]
+
+  [#local nsgFlowLogEnabled = environmentObject.Operations.FlowLogs.Enabled!
+    segmentObject.Operations.FlowLogs.Enabled!
+    solution.Logging.EnableFlowLogs ]
+
+  [#local networkCIDR = (network.CIDR)?has_content?then(
+    network.CIDR.Address + "/" + network.CIDR.Mask,
+    solution.Address.CIDR )]
+
+  [#local networkAddress = networkCIDR?split("/")[0] ]
+  [#local networkMask = (networkCIDR?split("/")[1])?number ]
+  [#local baseAddress = networkAddress?split(".") ]
+
+  [#local addressOffset = baseAddress[2]?number*256 + baseAddress[3]?number]
+  [#local addressesPerTier = powersOf2[getPowerOf2(powersOf2[32 - networkMask]/(network.Tiers.Order?size))]]
+  [#local addressesPerZone = powersOf2[getPowerOf2(addressesPerTier / (network.Zones.Order?size))]]
+  [#local subnetMask = 32 - powersOf2?seq_index_of(addressesPerZone)]
+
+  [#-- Define subnets --]
+  [#local subnets = {}]
+  [#list segmentObject.Network.Tiers.Order as tierId]
+    [#local networkTier = getTier(tierId) ]
+
+    [#-- Filter out to only valid tiers --]
+    [#if ! (networkTier?has_content && networkTier.Network.Enabled &&
+                networkTier.Network.Link.Tier == core.Tier.Id && networkTier.Network.Link.Component == core.Component.Id &&
+                (networkTier.Network.Link.Version!core.Version.Id) == core.Version.Id && (networkTier.Network.Link.Instance!core.Instance.Id) == core.Instance.Id)]
+        [#continue]
+    [/#if]
+
+    [#list zones as zone]
+      [#local subnetId = formatDependentSubnetId(core.Id, networkTier.Id, zone.Id)]
+      [#local subnetName = formatName(core.FullName, networkTier.Name, zone.Name)]
+      [#local subnetAddress = addressOffset + (networkTier.Network.Index * addressesPerTier) + (zone.Index * addressesPerZone)]
+      [#local subnetCIDR = baseAddress[0] + "." + baseAddress[1] + "." + (subnetAddress/256)?int + "." + subnetAddress%256 + "/" + subnetMask]
+      [#local routeId = formatDependentRouteTableRouteId(subnetId)]
+
+      [#local subnets =  mergeObjects( subnets, {
+        networkTier.Id : {
+          zone.Id : {
+            "subnet" : {
+              "Id" : subnetId,
+              "Name" : subnetName,
+              "Address" : subnetCIDR,
+              "Type" : AZURE_SUBNET_RESOURCE_TYPE
+            },
+            "routeTableRoute" : {
+              "Id" : routeId,
+              "Type" : AZURE_ROUTE_TABLE_ROUTE_RESOURCE_TYPE
+            }
+          }
+        }
+      })]
+    [/#list]
+  [/#list]
+
+  [#assign componentState=
+    {
+      "Resources" : {
+        "vnet" : {
+          "Id" : vnetId,
+          "Name" : vnetName,
+          "Address" : networkAddress + "/" + networkMask,
+          "Type" : AZURE_VIRTUAL_NETWORK_RESOURCE_TYPE
+        },
+        "subnets" : subnets
+      }
+      nsgFlowLogEnabled?then(
+        {
+          "flowlogs" : {
+            "networkWatcherFlowlog" : {
+              "Id" : nsgFlowlogId,
+              "Type" : AZURE_NETWORK_WATCHER_RESOURCE_TYPE
+            }
+          }
+        }
+      ),
+      "Attributes" : {},
+      "Roles" : {
+        "Inbound" : {},
+        "Outbound" : {}
+      }
+    }
+  ]
+[/#macro]
+
+[#macro azure_networkroute_arm_state occurrence parent={} baseState={}]
+
+  [#local core = occurrence.Core]
+  [#local solution = occurrence.Configuration.Solution]
+
+  [#local routeTableId = formatDependentRouteTableId(core.Id)]
+
+  [#local routeTables = {}]
+  [#list segmentObject.Network.Tiers.Order as tierId]
+    
+    [#-- Filter out to only valid tiers --]
+    [#local networkTier = getTier(tierId) ]
+    [#if ! (networkTier?has_content && networkTier.Network.Enabled)]
+        [#continue]
+    [/#if]
+
+    [#list zones as zone]
+      [#local zoneRouteTableId = formatId(routeTableId, zone.Id)]
+      [#local zoneRouteTableName = formatName(routeTableId, zone.Id)]
+
+      [#local routeTables = mergeObjects(routeTables, {
+        zone.Id : {
+          "routeTable" : {
+            "Id" : zoneRouteTableId,
+            "Name" : zoneRouteTableName,
+            "Type" : AZURE_ROUTE_TABLE_RESOURCE_TYPE
+          }
+        }
+      })]
+    [/#list]
+  [/#list]
+
+  [#assign componentState =
+    {
+      "Resources" : {
+        "routeTables" : routeTables
+      },
+      "Attributes" : {},
+      "Roles" : {
+          "Inbound" : {},
+          "Outbound" : {}
+      }
+    }
+  ]
+[/#macro]
+
+[#-- As a subcomponent, this NetworkACL is using a NetworkSecurityGroup
+resource. It remains "networkacl" in name to ensure there is no clash
+with any future networkSecurityGroup components. When referring to
+the Resource alone, it will remain NetworkSecurityGroup for clarity
+as Azure does not have NetworkACLs.--]
+[#macro azure_networkacl_arm_state occurence parent={} baseState={}]
+
+  [#local core = occurrence.Core]
+  [#local solution = occurrence.Configuration.Solution]
+
+  [#local vnetId = formatVirtualNetworkId(core.Id)]
+  [#local networkSecurityGroupId = formatDependentNetworkSecurityGroupId(vnetId)]
+  [#local nsgId = formatNetworkSecurityGroupId(core.Id)]
+  [#local nsgName = formatName(core.Name)]
+
+  [#list segmentObject.Network.Tiers.Order as tierId]
+  
+    [#-- Filter out to only valid tiers --]
+    [#local networkTier = getTier(tierId) ]
+    [#if ! (networkTier?has_content && networkTier.Network.Enabled)]
+        [#continue]
+    [/#if]
+
+    [#list zones as zone]
+
+      [#local networkSecurityGroupRules = {}]
+      [#list solution.Rules as id, rule]
+        [#local networkSecurityGroupRules += {
+          rule.Id : {
+            "Id" : formatDependentSecurityRuleId(networkSecurityGroupId, rule.Id),
+            "Type" : AZURE_VIRTUAL_NETWORK_SECURITY_GROUP_SECURITY_RULE_RESOURCE_TYPE
+          }
+        }]
+      [/#list]
+
+    [/#list]
+  [/#list]
+
+  [#assign componentState =
+    {
+      "Resources" : {
+        "networkSecurityGroup" : {
+          "Id" : nsgId,
+          "Name" : nsgName,
+          "Type" : AZURE_VIRTUAL_NETWORK_SECURITY_GROUP_RESOURCE_TYPE
+        },
+        "rules" : networkSecurityGroupRules
+      },
+      "Attributes" : {},
+      "Roles" : {
+        "Inbound" : {},
+        "Outbound" : {}
+      }
+    }
+  ]
+[/#macro]

--- a/masterData.ftl
+++ b/masterData.ftl
@@ -12,6 +12,7 @@
           "a": {
             "Title": "Zone A",
             "Description": "Zone A"
+            "AzureId" : "eastus"
           }
         },
         "Accounts": {}

--- a/services/microsoft.network/id.ftl
+++ b/services/microsoft.network/id.ftl
@@ -1,0 +1,94 @@
+[#ftl]
+
+[#assign AZURE_APPLICATION_SECURITY_GROUP_RESOURCE_TYPE = "applicationSecurityGroups"]
+[#assign AZURE_ROUTE_TABLE_RESOURCE_TYPE = "routeTables"]
+[#assign AZURE_ROUTE_TABLE_ROUTE_RESOURCE_TYPE = "routes"]
+[#assign AZURE_SERVICE_ENDPOINT_POLICY_RESOURCE_TYPE = "serviceEndpointPolicies"]
+[#assign AZURE_SERVICE_ENDPOINT_POLICY_DEFINITION_RESOURCE_TYPE = "serviceEndpointPolicyDefinitions"]
+[#assign AZURE_SUBNET_RESOURCE_TYPE = "subnets"]
+[#assign AZURE_VIRTUAL_NETWORK_RESOURCE_TYPE = "virtualNetworks"]
+[#assign AZURE_VIRTUAL_NETWORK_PEERING_RESOURCE_TYPE = "virtualNetworkPeerings"]
+[#assign AZURE_VIRTUAL_NETWORK_SECURITY_GROUP_RESOURCE_TYPE = "networkSecurityGroups"]
+[#assign AZURE_VIRTUAL_NETWORK_SECURITY_GROUP_SECURITY_RULE_RESOURCE_TYPE = "securityRules"]
+[#assign AZURE_NETWORK_WATCHER_RESOURCE_TYPE = "networkWatchers"]
+
+[#function formatDependentNetworkWatcherId resourceId extensions...]
+  [#return formatDependentResourceId(
+    AZURE_NETWORK_WATCHER_RESOURCE_TYPE
+    resourceId,
+    extensions)]
+[/#function]
+
+[#function formatDependentApplicationSecurityGroupId resourceId extensions...]
+  [#return formatDependentResourceId(
+    AZURE_APPLICATION_SECURITY_GROUP_RESOURCE_TYPE
+    resourceId,
+    extensions)]
+[/#function]
+
+[#function formatDependentRouteTableId resourceId extensions...]
+  [#return formatDependentResourceId(
+    AZURE_ROUTE_TABLE_RESOURCE_TYPE,
+    resourceId,
+    extensions)]
+[/#function]
+[#function formatDependentRouteTableRouteId resourceId extensions...]
+  [#return formatDependentResourceId(
+    AZURE_ROUTE_TABLE_ROUTE_RESOURCE_TYPE,
+    resourceId,
+    extensions)]
+[/#function]
+
+[#function formatDependentServiceEndpointPolicyId resourceId extensions...]
+  [#return formatDependentResourceId(
+    AZURE_SERVICE_ENDPOINT_POLICY_RESOURCE_TYPE,
+    resourceId,
+    extensions)]
+[/#function]
+
+[#function formatDependentServiceEndpointPolicyDefinitionId resourceId extensions...]
+  [#return formatDependentResourceId(
+    AZURE_SERVICE_ENDPOINT_POLICY_DEFINITION_RESOURCE_TYPE,
+    resourceId,
+    extensions)]
+[/#function]
+
+[#function formatDependentSubnetId resourceId extensions...]
+  [#return formatDependentResourceId(
+    AZURE_SUBNET_RESOURCE_TYPE,
+    resourceId,
+    extensions)]
+[/#function]
+
+[#function formatVirtualNetworkId ids...]
+  [#return formatResourceId(
+    AZURE_VIRTUAL_NETWORK_RESOURCE_TYPE,
+    ids)]
+[/#function]
+
+[#function formatDependentVirtualNetworkPeeringId resourceId extensions...]
+  [#return formatDependentResourceId(
+    AZURE_VIRTUAL_NETWORK_PEERING_RESOURCE_TYPE,
+    resourceId,
+    extensions)]
+[/#function]
+
+[#function formatDependentNetworkSecurityGroupId resourceId extensions...]
+  [#return formatDependentResourceId(
+    AZURE_VIRTUAL_NETWORK_SECURITY_GROUP_RESOURCE_TYPE,
+    resourceId,
+    extensions)]
+[/#function]
+
+[#function formatNetworkSecurityGroupId ids...]
+  [#return formatResourceId(
+    AZURE_VIRTUAL_NETWORK_SECURITY_GROUP_RESOURCE_TYPE,
+    ids)]
+[/#function]
+
+[#function formatDependentSecurityRuleId resourceId extensions...]
+  [#return formatDependentResourceId(
+    AZURE_VIRTUAL_NETWORK_SECURITY_GROUP_SECURITY_RULE_RESOURCE_TYPE,
+    resourceId,
+    extensions)]
+[/#function]

--- a/services/microsoft.network/resource.ftl
+++ b/services/microsoft.network/resource.ftl
@@ -1,5 +1,56 @@
 [#ftl]
 
+[#assign azureResourceProfiles +=
+  {
+    AZURE_NETWORK_SERVICE : {
+      AZURE_APPLICATION_SECURITY_GROUP_RESOURCE_TYPE : {
+        "apiVersion" : "2019-04-01",
+        "type" : "Microsoft.Network/applicationSecurityGroups"
+      },
+      AZURE_ROUTE_TABLE_RESOURCE_TYPE : {
+        "apiVersion" : "2019-02-01",
+        "type" : "Microsoft.Network/routeTables"
+      },
+      AZURE_ROUTE_TABLE_ROUTE_RESOURCE_TYPE : {
+        "apiVersion" : "2019-02-01",
+        "type" : "Microsoft.Network/routeTables/routes"
+      },
+      AZURE_SERVICE_ENDPOINT_POLICY_RESOURCE_TYPE : {
+        "apiVersion" : "2019-02-01",
+        "type" : "Microsoft.Network/serviceEndpointPolicies"
+      },
+      AZURE_SERVICE_ENDPOINT_POLICY_DEFINITION_RESOURCE_TYPE : {
+        "apiVersion" : "2019-02-01",
+        "type" : "Microsoft.Network/serviceEndpointPolicies/serviceEndpointPolicyDefinitions"
+      },
+      AZURE_SUBNET_RESOURCE_TYPE : {
+        "apiVersion" : "2019-02-01",
+        "type" : "Microsoft.Network/virtualNetworks/subnets"
+      },
+      AZURE_VIRTUAL_NETWORK_RESOURCE_TYPE : {
+        "apiVersion" : "2019-02-01",
+        "type" : "Microsoft.Network/virtualNetworks"
+      },
+      AZURE_VIRTUAL_NETWORK_PEERING_RESOURCE_TYPE : {
+        "apiVersion" : "2019-02-01",
+        "type" : "Microsoft.Network/virtualNetworks/virtualNetworkPeerings"
+      },
+      AZURE_VIRTUAL_NETWORK_SECURITY_GROUP_RESOURCE_TYPE : {
+        "apiVersion" : "2019-02-01",
+        "type" : "Microsoft.Network/networkSecurityGroups"
+      },
+      AZURE_VIRTUAL_NETWORK_SECURITY_GROUP_SECURITY_RULE_RESOURCE_TYPE : {
+        "apiVersion" : "2019-04-01",
+        "type" : "Microsoft.Network/networkSecurityGroups/securityRules"
+      },
+      AZURE_NETWORK_WATCHER_RESOURCE_TYPE : {
+        "apiVersion" : "2019-04-01",
+        "type" : "Microsoft.Network/networkWatchers"
+      }
+    }
+  }
+]
+
 [#assign VIRTUAL_NETWORK_OUTPUT_MAPPINGS = 
   {
     REFERENCE_ATTRIBUTE_TYPE : {
@@ -26,8 +77,7 @@
 [#macro createApplicationSecurityGroup name location tags={}]
   [@armResource
     name=name
-    type="Microsoft.Network/applicationSecurityGroups"
-    apiVersion="2019-04-01"
+    profile=AZURE_APPLICATION_SECURITY_GROUP_RESOURCE_TYPE
     location=location
     tags=tags
   /]
@@ -56,8 +106,7 @@
 
   [@armResource
     name=name
-    type="Microsoft.Network/networkSecurityGroups/securityRules"
-    apiVersion="2019-04-01"
+    profile=AZURE_VIRTUAL_NETWORK_SECURITY_GROUP_SECURITY_RULE_RESOURCE_TYPE
     dependsOn=dependsOn
     properties=  
       {
@@ -94,8 +143,7 @@
 
   [@armResource
     name=name
-    type="Microsoft.Network/routeTables/routes"
-    apiVersion="2019-02-01"
+    profile=AZURE_ROUTE_TABLE_ROUTE_RESOURCE_TYPE
     properties=
       {
         "nextHopType" : nextHopType
@@ -120,8 +168,7 @@
 
   [@armResource
     name=name
-    type="Microsoft.Network/routeTables"
-    apiVersion="2019-02-01"
+    profile=AZURE_ROUTE_TABLE_RESOURCE_TYPE
     location=location
     tags=tags
     properties=
@@ -145,8 +192,7 @@
 
   [@armResource
     name=name
-    type="Microsoft.Network/networkSecurityGroups"
-    apiVersion="2019-02-01"
+    profile=AZURE_VIRTUAL_NETWORK_SECURITY_GROUP_RESOURCE_TYPE
     location=location
     tags=tags
     resources=resources
@@ -165,8 +211,7 @@
 
   [@armResource
     name=name
-    type="Microsoft.Network/serviceEndpointPolicies/serviceEndpointPolicyDefinitions"
-    apiVersion="2019-02-01"
+    profile=AZURE_SERVICE_ENDPOINT_POLICY_DEFINITION_RESOURCE_TYPE
     properties=
       {} +
       attributeIfContent("description", description) +
@@ -185,9 +230,8 @@
 
   [@armResource 
     name=name
-    type="Microsoft.Network/serviceEndpointPolicies"
+    profile=AZURE_SERVICE_ENDPOINT_POLICY_RESOURCE_TYPE
     location=location
-    apiVersion="2019-02-01"
     dependsOn=dependsOn
     tags=tags
   /]
@@ -259,8 +303,7 @@
 
   [@armResource
     name=name
-    type="Microsoft.Network/virtualNetworks/subnets"
-    apiVersion="2019-02-01"
+    profile=AZURE_SUBNET_RESOURCE_TYPE
     properties=
       {} +
       attributeIfContent("addressPrefix", addressPrefix) +
@@ -290,8 +333,7 @@
 
   [@armResource
     name=name
-    type="Microsoft.Network/virtualNetworks/virtualNetworkPeerings"
-    apiVersion="2019-02-01"
+    profile=AZURE_VIRTUAL_NETWORK_PEERING_RESOURCE_TYPE
     properties=
       {} +
       attributeIfTrue("allowVNetAccess", allowVNetAccess, allowVNetAccess) +
@@ -316,8 +358,7 @@
 
   [@armResource
     name=name
-    type="Microsoft.Network/virtualNetworks"
-    apiVersion="2019-02-01"
+    profile=AZURE_VIRTUAL_NETWORK_RESOURCE_TYPE
     location=location
     outputs=outputs
     dependsOn=dependsOn
@@ -388,8 +429,7 @@ https://feedback.azure.com/forums/217313-networking/suggestions/37713784-arm-tem
 
   [@armResource
     name=name
-    type="Microsoft.Network/networkWatchers"
-    apiVersion="2019-04-01"
+    profile=AZURE_NETWORK_WATCHER_RESOURCE_TYPE
     properties=
       { "enabled" : true } +
       attributeIfContent("targetResourceId", getReference(targetResourceId)) +

--- a/services/microsoft.network/resource.ftl
+++ b/services/microsoft.network/resource.ftl
@@ -1,16 +1,5 @@
 [#ftl]
 
-[#-- 
-Some functions are paired with a corresponding Macro in the event
-that a resource can be both defined as a stand-alone Resource OR as
-a property within a parent Resource (this is seperate to a sub-resource).
-
-An example being a RouteTable can be both a stand-alone resource, or in 
-an object array within a VirtualNetwork's property list. The macro defines
-the standalone Resource, whereas the Object function defines the itterable 
-property object. This allows flexability for Component authors.
---]
-
 [#assign VIRTUAL_NETWORK_OUTPUT_MAPPINGS = 
   {
     REFERENCE_ATTRIBUTE_TYPE : {
@@ -34,21 +23,6 @@ property object. This allows flexability for Component authors.
   }
 ]
 
-[#function getApplicationSecurityGroupObject 
-  resourceId
-  location
-  tags={}
-  properties={}]
-
-  [#return 
-    {
-      "id" : resourceId,
-      "location" : location,
-      "properties" : properties
-    } +
-    attributeIfContent("tags", tags)
-  ]
-[/#function]
 [#macro createApplicationSecurityGroup name location tags={}]
   [@armResource
     name=name
@@ -59,7 +33,8 @@ property object. This allows flexability for Component authors.
   /]
 [/#macro]
 
-[#function getNetworkSecurityGroupSecurityRulesObject
+[#macro createNetworkSecurityGroupSecurityRule
+  name
   protocol
   access
   direction
@@ -74,32 +49,7 @@ property object. This allows flexability for Component authors.
   destinationAddressPrefixes=""
   destinationApplicationSecurityGroups=[]
   description=""
-  priority=""]
-
-  [#return
-    {
-      "access" : access,
-      "direction" : direction,
-      "protocol" : protocol
-    } +
-    attributeIfContent("sourceAddressPrefix", sourceAddressPrefix) +
-    attributeIfContent("sourceAddressPrefixes", asArray(sourceAddressPrefixes)) +
-    attributeIfContent("sourcePortRange", sourcePortRange) +
-    attributeIfContent("sourcePortRanges, asArray(sourcePortRanges)) +
-    attributeIfContent("sourceApplicationSecurityGroups", asArray(sourceApplicationSecurityGroups)) +
-    attributeIfContent("destinationPortRange", destinationPortRange) +
-    attributeIfContent("destinationPortRanges", asArray(destinationPortRanges)) +
-    attributeIfContent("destinationAddressPrefix", destinationAddressPrefix) +
-    attributeIfContent("destinationAddressPrefixes", asArray(destinationAddressPrefixes)) +
-    attributeIfContent("destinationApplicationSecurityGroups", asArray(destinationApplicationSecurityGroups)) +
-    attributeIfContent("description", description) +
-    attributeIfContent("priority", priority)
-  ]
-
-[/#function]
-[#macro createNetworkSecurityGroupSecurityRules
-  name
-  properties
+  priority=""
   tags={}
   outputs={}
   dependsOn=[]]
@@ -109,29 +59,35 @@ property object. This allows flexability for Component authors.
     type="Microsoft.Network/networkSecurityGroups/securityRules"
     apiVersion="2019-04-01"
     dependsOn=dependsOn
-    properties=properties
+    properties=  
+      {
+        "access" : access,
+        "direction" : direction,
+        "protocol" : protocol
+      } +
+      attributeIfContent("sourceAddressPrefix", sourceAddressPrefix) +
+      attributeIfContent("sourceAddressPrefixes", asArray(sourceAddressPrefixes)) +
+      attributeIfContent("sourcePortRange", sourcePortRange) +
+      attributeIfContent("sourcePortRanges, asArray(sourcePortRanges)) +
+      attributeIfContent("sourceApplicationSecurityGroups", asArray(sourceApplicationSecurityGroups)) +
+      attributeIfContent("destinationPortRange", destinationPortRange) +
+      attributeIfContent("destinationPortRanges", asArray(destinationPortRanges)) +
+      attributeIfContent("destinationAddressPrefix", destinationAddressPrefix) +
+      attributeIfContent("destinationAddressPrefixes", asArray(destinationAddressPrefixes)) +
+      attributeIfContent("destinationApplicationSecurityGroups", asArray(destinationApplicationSecurityGroups)) +
+      attributeIfContent("description", description) +
+      attributeIfContent("priority", priority)
     tags=tags
     outputs=outputs
   /]
   
 [/#macro]
 
-[#function getRouteTableRouteObject 
-  nextHopType 
-  addressPrefix="" 
-  nextHopIpAddress=""]
-
-  [#return
-    {
-      "nextHopType" : nextHopType
-    } + 
-    attributeIfContent("addressPrefix", addressPrefix) +
-    attributeIfContent("nextHopIpAddress", nextHopIpAddress)
-  ]
-[/#function]
 [#macro createRouteTableRoute
   name
-  properties={}
+  nextHopType 
+  addressPrefix="" 
+  nextHopIpAddress=""
   dependsOn=[]
   outputs={}
   tags={}]
@@ -140,7 +96,12 @@ property object. This allows flexability for Component authors.
     name=name
     type="Microsoft.Network/routeTables/routes"
     apiVersion="2019-02-01"
-    properties=properties
+    properties=
+      {
+        "nextHopType" : nextHopType
+      } + 
+      attributeIfContent("addressPrefix", addressPrefix) +
+      attributeIfContent("nextHopIpAddress", nextHopIpAddress)
     dependsOn=dependsOn
     outputs=outputs
     tags=tags
@@ -148,24 +109,12 @@ property object. This allows flexability for Component authors.
 
 [/#macro]
 
-[#function getRouteTableObject
-  id=""
-  routes=[]
-  disableBgpRoutePropagation=false
-  ]
-
-  [#return
-    {} +
-    attributeIfContent("id", getReference(id))
-    attributeIfContent("routes", asArray(routes)) +
-    attributeIfTrue("disableBgpRoutePropagation", disableBgpRoutePropagation, disableBgpRoutePropagation)
-  ]
-[/#function]
 [#macro createRouteTable
   name
+  routes=[]
+  disableBgpRoutePropagation=false
   location=""
   tags={}
-  properties={}
   dependsOn=[]
   outputs={}]
 
@@ -175,30 +124,18 @@ property object. This allows flexability for Component authors.
     apiVersion="2019-02-01"
     location=location
     tags=tags
-    properties=properties
+    properties=
+      {} +
+      attributeIfContent("routes", asArray(routes)) +
+      attributeIfTrue("disableBgpRoutePropagation", disableBgpRoutePropagation, disableBgpRoutePropagation)
     dependsOn=dependsOn
     outputs=outputs
   /]
 
 [/#macro]
 
-[#function getNetworkSecurityGroupObject
-  id=""
-  securityRules=[]
-  defaultSecurityRules=[]
-  resourceGuid=""]
-
-  [#return
-    {} +
-    attributeIfContent("id", getReference(id)) +
-    attributeIfContent("securityRules", asArray(securityRules)) +
-    attributeIfContent("defaultSecurityRules", asArray(defaultSecurityRules)) +
-    attributeIfContent("resourceGuid", resourceGuid)
-  ]
-[/#function]
 [#macro createNetworkSecurityGroup
   name
-  properties
   location=""
   tags={}
   resources=[]
@@ -212,28 +149,17 @@ property object. This allows flexability for Component authors.
     apiVersion="2019-02-01"
     location=location
     tags=tags
-    properties=properties
     resources=resources
     dependsOn=dependsOn
     outputs=outputs
   /]
 [/#macro]
 
-[#function getServiceEndpointPolicyDefinitionObject
-  description=""
-  service=""
-  serviceResources=[]]
-
-  [#return
-    {} +
-    attributeIfContent("description", description) +
-    attributeIfContent("service", service) +
-    attributeIfContent("serviceResources", asArray(serviceResources))
-  ]
-[/#function]
 [#macro createServiceEndpointPolicyDefinition
   name
-  properties
+  description=""
+  service=""
+  serviceResources=[]
   dependsOn=[]
   outputs={}]
 
@@ -241,23 +167,18 @@ property object. This allows flexability for Component authors.
     name=name
     type="Microsoft.Network/serviceEndpointPolicies/serviceEndpointPolicyDefinitions"
     apiVersion="2019-02-01"
-    properties=properties
+    properties=
+      {} +
+      attributeIfContent("description", description) +
+      attributeIfContent("service", service) +
+      attributeIfContent("serviceResources", asArray(serviceResources))
     dependsOn=dependsOn
     outputs=outputs
   /]
 [/#macro]
 
-[#function getServiceEndpointPolicyObject
-  serviceEndpointPolicyDefinitions=[]]
-
-  [#return
-    {} +
-    attributeIfContent("serviceEndpointPolicyDefinitions", serviceEndpointPolicyDefinitions)
-  ]
-[/#function]
 [#macro createServiceEndpointPolicy
   name
-  properties
   location=""
   dependsOn=[]
   tags={}]
@@ -267,7 +188,6 @@ property object. This allows flexability for Component authors.
     type="Microsoft.Network/serviceEndpointPolicies"
     location=location
     apiVersion="2019-02-01"
-    properties=properties
     dependsOn=dependsOn
     tags=tags
   /]
@@ -294,7 +214,7 @@ property object. This allows flexability for Component authors.
   ]
 [/#function]
 
-[#function getSubnetLinks
+[#function getSubnetLink
   id=""
   resourceName=""
   linkedResourceType=""
@@ -313,7 +233,7 @@ property object. This allows flexability for Component authors.
     attributeIfContent("properties", properties)
   ]
 [/#function]
-[#function getSubnetServiceEndpoints
+[#function getSubnetServiceEndpoint
   serviceType=""
   locations=[]]
 
@@ -323,80 +243,48 @@ property object. This allows flexability for Component authors.
     attributeIfContent("locations", asArray(locations))
   ]
 [/#function]
-[#function getSubnetNatGateway gatewayId=""]
-  [#return {} + attributeIfContent("id", gatewayId)]
-[/#function]
-[#function getSubnetObject
+
+[#macro createSubnet
+  name
   addressPrefix=""
   addressPrefixes=[]
   networkSecurityGroup={}
   routeTable={}
-  natGateway={}
+  natGatewayId=""
   serviceEndpoints=[]
   serviceEndpointPolicies=[]
   resourceNavigationLinks=[]
   serviceAssociationLinks=[]
   delegations=[]]
 
-  [#return
-    {} +
-    attributeIfContent("addressPrefix", addressPrefix) +
-    attributeIfContent("addressPrefixes", asArray(addressPrefixes)) +
-    attributeIfContent("networkSecurityGroup", networkSecurityGroup) +
-    attributeIfContent("routeTable", routeTable) +
-    attributeIfContent("natGateway", natGateway) +
-    attributeIfContent("serviceEndpoints", asArray(serviceEndpoints)) +
-    attributeIfContent("serviceEndpointPolicies", asArray(serviceEndpointPolicies)) +
-    attributeIfContent("resourceNavigationLinks", asArray(resourceNavigationLinks)) +
-    attributeIfContent("serviceAssociationLinks", asArray(serviceAssociationLinks)) +
-    attributeIfContent("delegations", asArray(delegations))
-  ]
-[/#function]
-[#macro createSubnet
-  name
-  properties]
-
   [@armResource
     name=name
     type="Microsoft.Network/virtualNetworks/subnets"
     apiVersion="2019-02-01"
-    properties=properties
+    properties=
+      {} +
+      attributeIfContent("addressPrefix", addressPrefix) +
+      attributeIfContent("addressPrefixes", asArray(addressPrefixes)) +
+      attributeIfContent("networkSecurityGroup", networkSecurityGroup) +
+      attributeIfContent("routeTable", routeTable) +
+      attributeIfContent("natGateway", { "id" : natGatewayId } ) +
+      attributeIfContent("serviceEndpoints", asArray(serviceEndpoints)) +
+      attributeIfContent("serviceEndpointPolicies", asArray(serviceEndpointPolicies)) +
+      attributeIfContent("resourceNavigationLinks", asArray(resourceNavigationLinks)) +
+      attributeIfContent("serviceAssociationLinks", asArray(serviceAssociationLinks)) +
+      attributeIfContent("delegations", asArray(delegations))
   /]
 [/#macro]
 
-[#function getVnetPeeringObject
+[#macro createVnetPeering
+  name
   allowVNetAccess=false
   allowForwardedTraffic=false
   allowGatewayTransit=false
   useRemoteGateways=false
   remoteVirtualNetworkId=""
   remoteAddressSpacePrefixes=[]
-  peeringState=""]
-
-  [#local remoteVirtualNetwork =
-    {} +
-    attributeIfContent("id", remoteVirtualNetworkId)
-  ]
-
-  [#local remoteAddressSpace =
-    {} +
-    attributeIfContent("addressPrefixes", remoteAddressSpacePrefixes)
-  ]
-
-  [#return
-    {} +
-    attributeIfTrue("allowVNetAccess", allowVNetAccess, allowVNetAccess) +
-    attributeIfTrue("allowForwardedTraffic", allowForwardedTraffic, allowForwardedTraffic) +
-    attributeIfTrue("allowGatewayTransit", allowGatewayTransit, allowGatewayTransit) +
-    attributeIfTrue("useRemoteGateways", useRemoteGateways, useRemoteGateways) +
-    attributeIfContent("remoteVirtualNetwork", remoteVirtualNetwork) +
-    attributeIfContent("remoteAddressSpace", remoteAddressSpace) +
-    attributeIfContent("peeringState", peeringState)
-  ]
-[/#function]
-[#macro createVnetPeering
-  name
-  properties
+  peeringState=""
   outputs={}
   dependsOn=[]]
 
@@ -404,39 +292,24 @@ property object. This allows flexability for Component authors.
     name=name
     type="Microsoft.Network/virtualNetworks/virtualNetworkPeerings"
     apiVersion="2019-02-01"
-    properties=properties
+    properties=
+      {} +
+      attributeIfTrue("allowVNetAccess", allowVNetAccess, allowVNetAccess) +
+      attributeIfTrue("allowForwardedTraffic", allowForwardedTraffic, allowForwardedTraffic) +
+      attributeIfTrue("allowGatewayTransit", allowGatewayTransit, allowGatewayTransit) +
+      attributeIfTrue("useRemoteGateways", useRemoteGateways, useRemoteGateways) +
+      attributeIfContent("remoteVirtualNetwork", { "id" : remoteVirtualNetworkId } ) +
+      attributeIfContent("remoteAddressSpace", { "addressPrefixes" : asArray(remoteAddressSpacePrefixes) } ) +
+      attributeIfContent("peeringState", peeringState)
     outputs=outputs
     dependsOn=dependsOn
   /]
 [/#macro]
 
-[#function getVNetDHCPOptions dnsServers=[]]
-
-  [#local dhcpOptions = 
-    {} +
-    attributeIfContent("dnsServers", asArray(dnsServers))
-  ]
-
-  [#return 
-    {} +
-    attributeIfContent("dhcpOptions", dhcpOptions)
-  ]
-[/#function]
-[#function getVNetAddressSpace addressSpacePrefixes=[]]
-
-  [#local addressSpace =
-    {} +
-    attributeIfContent("addressPrefixes", asArray(addressSpacePrefixes))
-  ]
-
-  [#return
-    {} +
-    attributeIfContent("addressSpace", addressSpace)
-  ]
-[/#function]
 [#macro createVNet
   name
-  properties
+  dnsServers=[]
+  addressSpacePrefixes=[]
   location=regionId
   outputs={}
   dependsOn=[]]
@@ -445,10 +318,27 @@ property object. This allows flexability for Component authors.
     name=name
     type="Microsoft.Network/virtualNetworks"
     apiVersion="2019-02-01"
-    properties=properties
     location=location
     outputs=outputs
     dependsOn=dependsOn
+    properties=
+      {} +
+      attributeIfContent(
+        "addressSpace",
+        {} + 
+        attributeIfContent(
+          "addressPrefixes", 
+          asArray(addressSpacePrefixes)
+        )
+      ) +
+      attributeIfContent(
+        "dhcpOptions",
+        {} +
+        attributeIfContent(
+          "dnsServers", 
+          asArray(dnsServers)
+        )
+      )
   /]
 [/#macro]
 
@@ -457,70 +347,57 @@ via PowerShell. This is being developed by Microsoft and expected Jan 2020 - wil
 this implimentation at that time to ensure this object remains correct.
 https://feedback.azure.com/forums/217313-networking/suggestions/37713784-arm-template-support-for-nsg-flow-logs
  --]
-[#function getFlowLogsObject
+[#macro createNetworkWatcherFlowLog
+  name
   targetResourceId
   storageId
-  enabled
   targetResourceGuid=""
   workspaceId=""
   trafficAnalyticsInterval=""
   retentionPolicyEnabled=false
   retentionDays=""
   formatType=""
-  formatVersion=""]
+  formatVersion=""
+  location=""
+  outputs={}
+  dependsOn=[]]
 
-  [#if enabled]
+  [#local networkWatcherFlowAnalyticsConfiguration =
+    { "enabled" : true } +
+    attributeIfContent("workspaceId", workspaceId) +
+    attributeIfContent("trafficAnalyticsInterval", trafficAnalyticsInterval)
+  ]
 
-    [#local networkWatcherFlowAnalyticsConfiguration =
+  [#local flowAnalyticsConfiguration =
+    { 
+      "networkWatcherFlowAnalyticsConfiguration" : networkWatcherFlowAnalyticsConfiguration
+    }
+  ]
+
+  [#local retentionPolicy=
+    {} +
+    attributeIfContent("days", retentionDays) +
+    attributeIfTrue("enabled", retentionPolicyEnabled, retentionPolicyEnabled)
+  ]
+
+  [#local format=
+    {}+
+    attributeIfContent("type", formatType) +
+    attributeIfContent("version", formatVersion)
+  ]
+
+  [@armResource
+    name=name
+    type="Microsoft.Network/networkWatchers"
+    apiVersion="2019-04-01"
+    properties=
       { "enabled" : true } +
-      attributeIfContent("workspaceId", workspaceId) +
-      attributeIfContent("trafficAnalyticsInterval", trafficAnalyticsInterval)
-    ]
-
-    [#local flowAnalyticsConfiguration =
-      { 
-        "networkWatcherFlowAnalyticsConfiguration" : networkWatcherFlowAnalyticsConfiguration
-      }
-    ]
-
-    [#local retentionPolicy=
-      {} +
-      attributeIfContent("days", retentionDays) +
-      attributeIfTrue("enabled", retentionPolicyEnabled, retentionPolicyEnabled)
-    ]
-
-    [#local format=
-      {}+
-      attributeIfContent("type", formatType) +
-      attributeIfContent("version", formatVersion)
-    ]
-
-    [#return
-      { "enabled" : enabled } +
       attributeIfContent("targetResourceId", getReference(targetResourceId)) +
       attributeIfContent("targetResourceGuid", targetResourceGuid) +
       attributeIfContent("storageId", storageId) +
       attributeIfContent("flowAnalyticsConfiguration", flowAnalyticsConfiguration) +
       attributeIfContent("retentionPolicy", retentionPolicy) +
       attributeIfContent("format", format)
-    ]
-  [#else]
-    [#return {}]
-  [/#if]
-
-[/#function]
-[#macro createNetworkWatcher
-  name
-  properties=
-  location=""
-  outputs={}
-  dependsOn=[]]
-
-  [@armResource
-    name=name
-    type="Microsoft.Network/networkWatchers"
-    apiVersion="2019-04-01"
-    properties=properties
     location=location
     outputs=outputs
     dependsOn=dependsOn

--- a/services/microsoft.network/resource.ftl
+++ b/services/microsoft.network/resource.ftl
@@ -1,0 +1,528 @@
+[#ftl]
+
+[#-- 
+Some functions are paired with a corresponding Macro in the event
+that a resource can be both defined as a stand-alone Resource OR as
+a property within a parent Resource (this is seperate to a sub-resource).
+
+An example being a RouteTable can be both a stand-alone resource, or in 
+an object array within a VirtualNetwork's property list. The macro defines
+the standalone Resource, whereas the Object function defines the itterable 
+property object. This allows flexability for Component authors.
+--]
+
+[#assign VIRTUAL_NETWORK_OUTPUT_MAPPINGS = 
+  {
+    REFERENCE_ATTRIBUTE_TYPE : {
+      "Property" : "id"
+    }
+  }
+]
+
+[#assign SUBNET_OUTPUT_MAPPINGS =
+  {
+    REFERENCE_ATTRIBUTE_TYPE : {
+      "Property : "id"
+    }
+  }
+]
+
+[#assign outputMappings += 
+  {
+    AZURE_VIRTUAL_NETWORK_RESOURCE_TYPE : VIRTUAL_NETWORK_OUTPUT_MAPPINGS,
+    AZURE_SUBNET_RESOURCE_TYPE : SUBNET_OUTPUT_MAPPINGS
+  }
+]
+
+[#function getApplicationSecurityGroupObject 
+  resourceId
+  location
+  tags={}
+  properties={}]
+
+  [#return 
+    {
+      "id" : resourceId,
+      "location" : location,
+      "properties" : properties
+    } +
+    attributeIfContent("tags", tags)
+  ]
+[/#function]
+[#macro createApplicationSecurityGroup name location tags={}]
+  [@armResource
+    name=name
+    type="Microsoft.Network/applicationSecurityGroups"
+    apiVersion="2019-04-01"
+    location=location
+    tags=tags
+  /]
+[/#macro]
+
+[#function getNetworkSecurityGroupSecurityRulesObject
+  protocol
+  access
+  direction
+  sourceAddressPrefix=""
+  sourceAddressPrefixes=[]
+  sourcePortRange=""
+  sourcePortRanges=[]
+  sourceApplicationSecurityGroups=[]
+  destinationPortRange=""
+  destinationPortRanges=[]
+  destinationAddressPrefix=""
+  destinationAddressPrefixes=""
+  destinationApplicationSecurityGroups=[]
+  description=""
+  priority=""]
+
+  [#return
+    {
+      "access" : access,
+      "direction" : direction,
+      "protocol" : protocol
+    } +
+    attributeIfContent("sourceAddressPrefix", sourceAddressPrefix) +
+    attributeIfContent("sourceAddressPrefixes", asArray(sourceAddressPrefixes)) +
+    attributeIfContent("sourcePortRange", sourcePortRange) +
+    attributeIfContent("sourcePortRanges, asArray(sourcePortRanges)) +
+    attributeIfContent("sourceApplicationSecurityGroups", asArray(sourceApplicationSecurityGroups)) +
+    attributeIfContent("destinationPortRange", destinationPortRange) +
+    attributeIfContent("destinationPortRanges", asArray(destinationPortRanges)) +
+    attributeIfContent("destinationAddressPrefix", destinationAddressPrefix) +
+    attributeIfContent("destinationAddressPrefixes", asArray(destinationAddressPrefixes)) +
+    attributeIfContent("destinationApplicationSecurityGroups", asArray(destinationApplicationSecurityGroups)) +
+    attributeIfContent("description", description) +
+    attributeIfContent("priority", priority)
+  ]
+
+[/#function]
+[#macro createNetworkSecurityGroupSecurityRules
+  name
+  properties
+  tags={}
+  outputs={}
+  dependsOn=[]]
+
+  [@armResource
+    name=name
+    type="Microsoft.Network/networkSecurityGroups/securityRules"
+    apiVersion="2019-04-01"
+    dependsOn=dependsOn
+    properties=properties
+    tags=tags
+    outputs=outputs
+  /]
+  
+[/#macro]
+
+[#function getRouteTableRouteObject 
+  nextHopType 
+  addressPrefix="" 
+  nextHopIpAddress=""]
+
+  [#return
+    {
+      "nextHopType" : nextHopType
+    } + 
+    attributeIfContent("addressPrefix", addressPrefix) +
+    attributeIfContent("nextHopIpAddress", nextHopIpAddress)
+  ]
+[/#function]
+[#macro createRouteTableRoute
+  name
+  properties={}
+  dependsOn=[]
+  outputs={}
+  tags={}]
+
+  [@armResource
+    name=name
+    type="Microsoft.Network/routeTables/routes"
+    apiVersion="2019-02-01"
+    properties=properties
+    dependsOn=dependsOn
+    outputs=outputs
+    tags=tags
+  /]
+
+[/#macro]
+
+[#function getRouteTableObject
+  id=""
+  routes=[]
+  disableBgpRoutePropagation=false
+  ]
+
+  [#return
+    {} +
+    attributeIfContent("id", getReference(id))
+    attributeIfContent("routes", asArray(routes)) +
+    attributeIfTrue("disableBgpRoutePropagation", disableBgpRoutePropagation, disableBgpRoutePropagation)
+  ]
+[/#function]
+[#macro createRouteTable
+  name
+  location=""
+  tags={}
+  properties={}
+  dependsOn=[]
+  outputs={}]
+
+  [@armResource
+    name=name
+    type="Microsoft.Network/routeTables"
+    apiVersion="2019-02-01"
+    location=location
+    tags=tags
+    properties=properties
+    dependsOn=dependsOn
+    outputs=outputs
+  /]
+
+[/#macro]
+
+[#function getNetworkSecurityGroupObject
+  id=""
+  securityRules=[]
+  defaultSecurityRules=[]
+  resourceGuid=""]
+
+  [#return
+    {} +
+    attributeIfContent("id", getReference(id)) +
+    attributeIfContent("securityRules", asArray(securityRules)) +
+    attributeIfContent("defaultSecurityRules", asArray(defaultSecurityRules)) +
+    attributeIfContent("resourceGuid", resourceGuid)
+  ]
+[/#function]
+[#macro createNetworkSecurityGroup
+  name
+  properties
+  location=""
+  tags={}
+  resources=[]
+  dependsOn=[]
+  outputs={}
+  ]
+
+  [@armResource
+    name=name
+    type="Microsoft.Network/networkSecurityGroups"
+    apiVersion="2019-02-01"
+    location=location
+    tags=tags
+    properties=properties
+    resources=resources
+    dependsOn=dependsOn
+    outputs=outputs
+  /]
+[/#macro]
+
+[#function getServiceEndpointPolicyDefinitionObject
+  description=""
+  service=""
+  serviceResources=[]]
+
+  [#return
+    {} +
+    attributeIfContent("description", description) +
+    attributeIfContent("service", service) +
+    attributeIfContent("serviceResources", asArray(serviceResources))
+  ]
+[/#function]
+[#macro createServiceEndpointPolicyDefinition
+  name
+  properties
+  dependsOn=[]
+  outputs={}]
+
+  [@armResource
+    name=name
+    type="Microsoft.Network/serviceEndpointPolicies/serviceEndpointPolicyDefinitions"
+    apiVersion="2019-02-01"
+    properties=properties
+    dependsOn=dependsOn
+    outputs=outputs
+  /]
+[/#macro]
+
+[#function getServiceEndpointPolicyObject
+  serviceEndpointPolicyDefinitions=[]]
+
+  [#return
+    {} +
+    attributeIfContent("serviceEndpointPolicyDefinitions", serviceEndpointPolicyDefinitions)
+  ]
+[/#function]
+[#macro createServiceEndpointPolicy
+  name
+  properties
+  location=""
+  dependsOn=[]
+  tags={}]
+
+  [@armResource 
+    name=name
+    type="Microsoft.Network/serviceEndpointPolicies"
+    location=location
+    apiVersion="2019-02-01"
+    properties=properties
+    dependsOn=dependsOn
+    tags=tags
+  /]
+[/#macro]
+
+[#function getSubnetDelegation
+  id=""
+  name=""
+  serviceName=""
+  actions=[]]
+
+  [#local properties=
+    {} +
+    attributeIfContent("id", getReference(id))
+    attributeIfContent("serviceName", serviceName) +
+    attributeIfContent("actions", asArray(actions))
+  ]
+
+  [#return
+    {} +
+    attributeIfContent("id", id) + 
+    attributeIfContent("name", name) +
+    attributeIfContent("properties", properties)
+  ]
+[/#function]
+
+[#function getSubnetLinks
+  id=""
+  resourceName=""
+  linkedResourceType=""
+  resourceLink=""]
+
+  [#local properties=
+    {} +
+    attributeIfContent("linkedResourceType", linkedResourceType) +
+    attributeIfContent("link", resourceLink)
+  ]
+
+  [#return
+    {} +
+    attributeIfContent("id", getReference(id)) +
+    attributeIfContent("name", getReference(resourceName)) +
+    attributeIfContent("properties", properties)
+  ]
+[/#function]
+[#function getSubnetServiceEndpoints
+  serviceType=""
+  locations=[]]
+
+  [#return
+    {} + 
+    attributeIfContent("service", serviceType) +
+    attributeIfContent("locations", asArray(locations))
+  ]
+[/#function]
+[#function getSubnetNatGateway gatewayId=""]
+  [#return {} + attributeIfContent("id", gatewayId)]
+[/#function]
+[#function getSubnetObject
+  addressPrefix=""
+  addressPrefixes=[]
+  networkSecurityGroup={}
+  routeTable={}
+  natGateway={}
+  serviceEndpoints=[]
+  serviceEndpointPolicies=[]
+  resourceNavigationLinks=[]
+  serviceAssociationLinks=[]
+  delegations=[]]
+
+  [#return
+    {} +
+    attributeIfContent("addressPrefix", addressPrefix) +
+    attributeIfContent("addressPrefixes", asArray(addressPrefixes)) +
+    attributeIfContent("networkSecurityGroup", networkSecurityGroup) +
+    attributeIfContent("routeTable", routeTable) +
+    attributeIfContent("natGateway", natGateway) +
+    attributeIfContent("serviceEndpoints", asArray(serviceEndpoints)) +
+    attributeIfContent("serviceEndpointPolicies", asArray(serviceEndpointPolicies)) +
+    attributeIfContent("resourceNavigationLinks", asArray(resourceNavigationLinks)) +
+    attributeIfContent("serviceAssociationLinks", asArray(serviceAssociationLinks)) +
+    attributeIfContent("delegations", asArray(delegations))
+  ]
+[/#function]
+[#macro createSubnet
+  name
+  properties]
+
+  [@armResource
+    name=name
+    type="Microsoft.Network/virtualNetworks/subnets"
+    apiVersion="2019-02-01"
+    properties=properties
+  /]
+[/#macro]
+
+[#function getVnetPeeringObject
+  allowVNetAccess=false
+  allowForwardedTraffic=false
+  allowGatewayTransit=false
+  useRemoteGateways=false
+  remoteVirtualNetworkId=""
+  remoteAddressSpacePrefixes=[]
+  peeringState=""]
+
+  [#local remoteVirtualNetwork =
+    {} +
+    attributeIfContent("id", remoteVirtualNetworkId)
+  ]
+
+  [#local remoteAddressSpace =
+    {} +
+    attributeIfContent("addressPrefixes", remoteAddressSpacePrefixes)
+  ]
+
+  [#return
+    {} +
+    attributeIfTrue("allowVNetAccess", allowVNetAccess, allowVNetAccess) +
+    attributeIfTrue("allowForwardedTraffic", allowForwardedTraffic, allowForwardedTraffic) +
+    attributeIfTrue("allowGatewayTransit", allowGatewayTransit, allowGatewayTransit) +
+    attributeIfTrue("useRemoteGateways", useRemoteGateways, useRemoteGateways) +
+    attributeIfContent("remoteVirtualNetwork", remoteVirtualNetwork) +
+    attributeIfContent("remoteAddressSpace", remoteAddressSpace) +
+    attributeIfContent("peeringState", peeringState)
+  ]
+[/#function]
+[#macro createVnetPeering
+  name
+  properties
+  outputs={}
+  dependsOn=[]]
+
+  [@armResource
+    name=name
+    type="Microsoft.Network/virtualNetworks/virtualNetworkPeerings"
+    apiVersion="2019-02-01"
+    properties=properties
+    outputs=outputs
+    dependsOn=dependsOn
+  /]
+[/#macro]
+
+[#function getVNetDHCPOptions dnsServers=[]]
+
+  [#local dhcpOptions = 
+    {} +
+    attributeIfContent("dnsServers", asArray(dnsServers))
+  ]
+
+  [#return 
+    {} +
+    attributeIfContent("dhcpOptions", dhcpOptions)
+  ]
+[/#function]
+[#function getVNetAddressSpace addressSpacePrefixes=[]]
+
+  [#local addressSpace =
+    {} +
+    attributeIfContent("addressPrefixes", asArray(addressSpacePrefixes))
+  ]
+
+  [#return
+    {} +
+    attributeIfContent("addressSpace", addressSpace)
+  ]
+[/#function]
+[#macro createVNet
+  name
+  properties
+  location=regionId
+  outputs={}
+  dependsOn=[]]
+
+  [@armResource
+    name=name
+    type="Microsoft.Network/virtualNetworks"
+    apiVersion="2019-02-01"
+    properties=properties
+    location=location
+    outputs=outputs
+    dependsOn=dependsOn
+  /]
+[/#macro]
+
+[#-- TODO(rossmurr4y): Flow Logs object is not currently supported, though exists when created
+via PowerShell. This is being developed by Microsoft and expected Jan 2020 - will need to revisit
+this implimentation at that time to ensure this object remains correct.
+https://feedback.azure.com/forums/217313-networking/suggestions/37713784-arm-template-support-for-nsg-flow-logs
+ --]
+[#function getFlowLogsObject
+  targetResourceId
+  storageId
+  enabled
+  targetResourceGuid=""
+  workspaceId=""
+  trafficAnalyticsInterval=""
+  retentionPolicyEnabled=false
+  retentionDays=""
+  formatType=""
+  formatVersion=""]
+
+  [#if enabled]
+
+    [#local networkWatcherFlowAnalyticsConfiguration =
+      { "enabled" : true } +
+      attributeIfContent("workspaceId", workspaceId) +
+      attributeIfContent("trafficAnalyticsInterval", trafficAnalyticsInterval)
+    ]
+
+    [#local flowAnalyticsConfiguration =
+      { 
+        "networkWatcherFlowAnalyticsConfiguration" : networkWatcherFlowAnalyticsConfiguration
+      }
+    ]
+
+    [#local retentionPolicy=
+      {} +
+      attributeIfContent("days", retentionDays) +
+      attributeIfTrue("enabled", retentionPolicyEnabled, retentionPolicyEnabled)
+    ]
+
+    [#local format=
+      {}+
+      attributeIfContent("type", formatType) +
+      attributeIfContent("version", formatVersion)
+    ]
+
+    [#return
+      { "enabled" : enabled } +
+      attributeIfContent("targetResourceId", getReference(targetResourceId)) +
+      attributeIfContent("targetResourceGuid", targetResourceGuid) +
+      attributeIfContent("storageId", storageId) +
+      attributeIfContent("flowAnalyticsConfiguration", flowAnalyticsConfiguration) +
+      attributeIfContent("retentionPolicy", retentionPolicy) +
+      attributeIfContent("format", format)
+    ]
+  [#else]
+    [#return {}]
+  [/#if]
+
+[/#function]
+[#macro createNetworkWatcher
+  name
+  properties=
+  location=""
+  outputs={}
+  dependsOn=[]]
+
+  [@armResource
+    name=name
+    type="Microsoft.Network/networkWatchers"
+    apiVersion="2019-04-01"
+    properties=properties
+    location=location
+    outputs=outputs
+    dependsOn=dependsOn
+  /]
+[/#macro]

--- a/services/microsoft.network/resource.ftl
+++ b/services/microsoft.network/resource.ftl
@@ -67,12 +67,17 @@
   }
 ]
 
-[#assign outputMappings += 
-  {
-    AZURE_VIRTUAL_NETWORK_RESOURCE_TYPE : VIRTUAL_NETWORK_OUTPUT_MAPPINGS,
-    AZURE_SUBNET_RESOURCE_TYPE : SUBNET_OUTPUT_MAPPINGS
-  }
-]
+[@addOutputMapping 
+  provider=AZURE_PROVIDER
+  resourceType=AZURE_VIRTUAL_NETWORK_RESOURCE_TYPE
+  mappings=VIRTUAL_NETWORK_OUTPUT_MAPPINGS
+/]
+
+[@addOutputMapping 
+  provider=AZURE_PROVIDER
+  resourceType=AZURE_SUBNET_RESOURCE_TYPE
+  mappings=SUBNET_OUTPUT_MAPPINGS
+/]
 
 [#macro createApplicationSecurityGroup name location tags={}]
   [@armResource


### PR DESCRIPTION
Will be separating future services/components into their own PRs, so that component design/testing does not hold back the merge of new Services.

Service includes the following Resource definitions that will allow the creation of the standard Django Stack Network components listed in #25 :

- [virtualNetworks](https://docs.microsoft.com/en-us/azure/templates/microsoft.network/2019-02-01/virtualnetworks)
- [subnets](https://docs.microsoft.com/en-us/azure/templates/microsoft.network/2019-02-01/virtualnetworks/subnets)
- [networkSecurityGroups](https://docs.microsoft.com/en-us/azure/templates/microsoft.network/2019-02-01/networksecuritygroups)
- [routeTables](https://docs.microsoft.com/en-us/azure/templates/microsoft.network/2019-02-01/routetables)

also includes the following sub-Resource definitions that are required for complete definition of those above:
- [applicationSecurityGroups](https://docs.microsoft.com/en-us/azure/templates/microsoft.network/2019-02-01/applicationsecuritygroups)
- [routes](https://docs.microsoft.com/en-us/azure/templates/microsoft.network/2019-02-01/routetables/routes)
- [serviceEndpointPolicies](https://docs.microsoft.com/en-us/azure/templates/microsoft.network/2019-02-01/serviceendpointpolicies)
- [serviceEndpointDefinitions](https://docs.microsoft.com/en-us/azure/templates/microsoft.network/2019-02-01/serviceendpointpolicies/serviceendpointpolicydefinitions)
- [virtualNetworkPeerings](https://docs.microsoft.com/en-us/azure/templates/microsoft.network/2019-02-01/virtualnetworks/virtualnetworkpeerings)
- [securityRules](https://docs.microsoft.com/en-us/azure/templates/microsoft.network/2019-02-01/networksecuritygroups/securityrules)
- [NetworkWatcher](https://docs.microsoft.com/en-us/azure/templates/microsoft.network/2019-04-01/networkwatchers)

In Azure, many resources can be defined as either unique resources or, should the resource be very commonly associated with another - (like a subnet to a vnet) then you can often define the subnet as an attribute within the Properties of the parent resource - usually as an array (this is seperate to the standard sub-resource functionality of Azure). The structure of the Resource and the Property object are the same and so I have separated them out so as to offer the greatest flexibility when designing components.

Note: Though a configuration for NSG Flow Logs exists in ARM, it is currently unsupported but under development by Microsoft, due January 2020 (I'm sure thats a very rough estimate). I have incorporated Flow Logs into the component so as to factor in their logic now rather than having to revisit, however the Resource generated will need to be revisited when the Resource becomes officially supported.