### PR TITLE
Feat resource profile conditions

### DIFF
--- a/components/s3/setup.ftl
+++ b/components/s3/setup.ftl
@@ -95,7 +95,7 @@
 
         [@createBlobService 
             name=blobId
-            parentNames=[accountId]
+            accountId=accountId
             CORSBehaviours=solution.CORSBehaviours
             deleteRetentionPolicy=
                 (solution.Lifecycle.BlobRetentionDays)?has_content?then(
@@ -109,7 +109,8 @@
 
         [@createBlobServiceContainer 
             name=containerId
-            parentNames=[accountId, blobId]
+            accountId=accountId
+            blobId=blobId
             publicAccess=solution.PublicAccess.Enabled
             dependsOn=dependencies        
         /]

--- a/components/s3/setup.ftl
+++ b/components/s3/setup.ftl
@@ -95,6 +95,7 @@
 
         [@createBlobService 
             name=blobId
+            parentNames=[accountId]
             CORSBehaviours=solution.CORSBehaviours
             deleteRetentionPolicy=
                 (solution.Lifecycle.BlobRetentionDays)?has_content?then(
@@ -108,6 +109,7 @@
 
         [@createBlobServiceContainer 
             name=containerId
+            parentNames=[accountId, blobId]
             publicAccess=solution.PublicAccess.Enabled
             dependsOn=dependencies        
         /]

--- a/deploymentframeworks/arm/output.ftl
+++ b/deploymentframeworks/arm/output.ftl
@@ -88,13 +88,15 @@
             context=resourceProfile
         /]
     [/#if]
+    
+    [#local segmentedName = formatAzureResourceName(name, parentNames)]
 
     [@addToJsonOutput 
         name="resources"
         content=
             [
                 {
-                    "name": name,
+                    "name": segmentedName?lower_case,
                     "type": resourceProfile.type,
                     "apiVersion": resourceProfile.apiVersion,
                     "properties": properties
@@ -113,27 +115,39 @@
     /]
 
     [#list outputs as outputType,outputValue]
-        [#if outputValue.UseRef!false]
+        [#if outputType == REFERENCE_ATTRIBUTE_TYPE]
 
             [#-- format the ARM function: resourceId() --]
-            [#local reference=formatAzureResourceIdReference(name,type)]
+            [#local reference=formatAzureResourceIdReference(segmentedName, type)]
 
             [@armOutput
                 name=name
                 type="string"
                 value=reference
             /]
+            
         [#else]
+            [#if outputValue.Property?has_content!false]
 
-            [#-- format the ARM function: reference() --] 
-            [#local reference=formatAzureResourceReference(name,type)]
-       
-            [@armOutput
-                name=name
-                type="string"
-                value=reference   
-            /]
-
+                [#-- format the ARM function: reference() --] 
+                [#local reference=formatAzureResourceReference(
+                    segmentedName,
+                    type,
+                    "",
+                    parentNames,
+                    outputValue.Property!""
+                )]
+        
+                [@armOutput
+                    name=formatAttributeId(name, outputType)
+                    type="string"
+                    type=((value.Property)!false)?then(
+                        "string",
+                        "object"
+                    )
+                    value=reference
+                /] 
+            [/#if]
         [/#if]
     [/#list]
 [/#macro]
@@ -158,8 +172,7 @@
                 "outputs":
                     getOutputContent("outputs") +
                     getArmTemplateCoreOutputs()
-            } +
-            attributeIfContent("COTMessages", logMessages)
+            }
         /]
     [/#if]
 [/#macro]

--- a/deploymentframeworks/arm/output.ftl
+++ b/deploymentframeworks/arm/output.ftl
@@ -119,6 +119,8 @@
                     { "name" : segmentedName?lower_case }
                 )]
                 [#break]
+            [#case "parent_to_lower"]
+                [#break]
             [#default]
                 [@fatal
                     message="Azure Resource Profile Condition does not exist."

--- a/services/microsoft.managedidentity/resource.ftl
+++ b/services/microsoft.managedidentity/resource.ftl
@@ -5,7 +5,8 @@
         AZURE_IAM_SERVICE : {
             AZURE_USER_ASSIGNED_IDENTITY_RESOURCE_TYPE : {
                 "apiVersion" : "2018-11-30",
-                "type" : "Microsoft.ManagedIdentity/userAssignedIdentities"
+                "type" : "Microsoft.ManagedIdentity/userAssignedIdentities",
+                "conditions" : []
             }
         }
     }

--- a/services/microsoft.managedidentity/resource.ftl
+++ b/services/microsoft.managedidentity/resource.ftl
@@ -1,16 +1,14 @@
 [#ftl]
 
-[#assign azureResourceProfiles +=
-    {
-        AZURE_IAM_SERVICE : {
-            AZURE_USER_ASSIGNED_IDENTITY_RESOURCE_TYPE : {
-                "apiVersion" : "2018-11-30",
-                "type" : "Microsoft.ManagedIdentity/userAssignedIdentities",
-                "conditions" : []
-            }
+[@addResourceProfile
+    service=AZURE_IAM_SERVICE
+    resource=AZURE_USER_ASSIGNED_IDENTITY_RESOURCE_TYPE
+    profile=
+        {
+            "apiVersion" : "2018-11-30",
+            "type" : "Microsoft.ManagedIdentity/userAssignedIdentities"
         }
-    }
-]
+/]
 
 [#assign IDENTITY_OUTPUT_MAPPINGS =
     {

--- a/services/microsoft.network/resource.ftl
+++ b/services/microsoft.network/resource.ftl
@@ -5,47 +5,58 @@
     AZURE_NETWORK_SERVICE : {
       AZURE_APPLICATION_SECURITY_GROUP_RESOURCE_TYPE : {
         "apiVersion" : "2019-04-01",
-        "type" : "Microsoft.Network/applicationSecurityGroups"
+        "type" : "Microsoft.Network/applicationSecurityGroups",
+        "conditions" : []
       },
       AZURE_ROUTE_TABLE_RESOURCE_TYPE : {
         "apiVersion" : "2019-02-01",
-        "type" : "Microsoft.Network/routeTables"
+        "type" : "Microsoft.Network/routeTables",
+        "conditions" : []
       },
       AZURE_ROUTE_TABLE_ROUTE_RESOURCE_TYPE : {
         "apiVersion" : "2019-02-01",
-        "type" : "Microsoft.Network/routeTables/routes"
+        "type" : "Microsoft.Network/routeTables/routes",
+        "conditions" : []
       },
       AZURE_SERVICE_ENDPOINT_POLICY_RESOURCE_TYPE : {
         "apiVersion" : "2019-02-01",
-        "type" : "Microsoft.Network/serviceEndpointPolicies"
+        "type" : "Microsoft.Network/serviceEndpointPolicies",
+        "conditions" : []
       },
       AZURE_SERVICE_ENDPOINT_POLICY_DEFINITION_RESOURCE_TYPE : {
         "apiVersion" : "2019-02-01",
-        "type" : "Microsoft.Network/serviceEndpointPolicies/serviceEndpointPolicyDefinitions"
+        "type" : "Microsoft.Network/serviceEndpointPolicies/serviceEndpointPolicyDefinitions",
+        "conditions" : []
       },
       AZURE_SUBNET_RESOURCE_TYPE : {
         "apiVersion" : "2019-02-01",
-        "type" : "Microsoft.Network/virtualNetworks/subnets"
+        "type" : "Microsoft.Network/virtualNetworks/subnets",
+        "conditions" : []
       },
       AZURE_VIRTUAL_NETWORK_RESOURCE_TYPE : {
         "apiVersion" : "2019-02-01",
-        "type" : "Microsoft.Network/virtualNetworks"
+        "type" : "Microsoft.Network/virtualNetworks",
+        "conditions" : []
       },
       AZURE_VIRTUAL_NETWORK_PEERING_RESOURCE_TYPE : {
         "apiVersion" : "2019-02-01",
-        "type" : "Microsoft.Network/virtualNetworks/virtualNetworkPeerings"
+        "type" : "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
+        "conditions" : []
       },
       AZURE_VIRTUAL_NETWORK_SECURITY_GROUP_RESOURCE_TYPE : {
         "apiVersion" : "2019-02-01",
-        "type" : "Microsoft.Network/networkSecurityGroups"
+        "type" : "Microsoft.Network/networkSecurityGroups",
+        "conditions" : []
       },
       AZURE_VIRTUAL_NETWORK_SECURITY_GROUP_SECURITY_RULE_RESOURCE_TYPE : {
         "apiVersion" : "2019-04-01",
-        "type" : "Microsoft.Network/networkSecurityGroups/securityRules"
+        "type" : "Microsoft.Network/networkSecurityGroups/securityRules",
+        "conditions" : []
       },
       AZURE_NETWORK_WATCHER_RESOURCE_TYPE : {
         "apiVersion" : "2019-04-01",
-        "type" : "Microsoft.Network/networkWatchers"
+        "type" : "Microsoft.Network/networkWatchers",
+        "conditions" : []
       }
     }
   }

--- a/services/microsoft.network/resource.ftl
+++ b/services/microsoft.network/resource.ftl
@@ -1,66 +1,63 @@
 [#ftl]
 
-[#assign azureResourceProfiles +=
-  {
-    AZURE_NETWORK_SERVICE : {
-      AZURE_APPLICATION_SECURITY_GROUP_RESOURCE_TYPE : {
-        "apiVersion" : "2019-04-01",
-        "type" : "Microsoft.Network/applicationSecurityGroups",
-        "conditions" : []
-      },
-      AZURE_ROUTE_TABLE_RESOURCE_TYPE : {
-        "apiVersion" : "2019-02-01",
-        "type" : "Microsoft.Network/routeTables",
-        "conditions" : []
-      },
-      AZURE_ROUTE_TABLE_ROUTE_RESOURCE_TYPE : {
-        "apiVersion" : "2019-02-01",
-        "type" : "Microsoft.Network/routeTables/routes",
-        "conditions" : []
-      },
-      AZURE_SERVICE_ENDPOINT_POLICY_RESOURCE_TYPE : {
-        "apiVersion" : "2019-02-01",
-        "type" : "Microsoft.Network/serviceEndpointPolicies",
-        "conditions" : []
-      },
-      AZURE_SERVICE_ENDPOINT_POLICY_DEFINITION_RESOURCE_TYPE : {
-        "apiVersion" : "2019-02-01",
-        "type" : "Microsoft.Network/serviceEndpointPolicies/serviceEndpointPolicyDefinitions",
-        "conditions" : []
-      },
-      AZURE_SUBNET_RESOURCE_TYPE : {
-        "apiVersion" : "2019-02-01",
-        "type" : "Microsoft.Network/virtualNetworks/subnets",
-        "conditions" : []
-      },
-      AZURE_VIRTUAL_NETWORK_RESOURCE_TYPE : {
-        "apiVersion" : "2019-02-01",
-        "type" : "Microsoft.Network/virtualNetworks",
-        "conditions" : []
-      },
-      AZURE_VIRTUAL_NETWORK_PEERING_RESOURCE_TYPE : {
-        "apiVersion" : "2019-02-01",
-        "type" : "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
-        "conditions" : []
-      },
-      AZURE_VIRTUAL_NETWORK_SECURITY_GROUP_RESOURCE_TYPE : {
-        "apiVersion" : "2019-02-01",
-        "type" : "Microsoft.Network/networkSecurityGroups",
-        "conditions" : []
-      },
-      AZURE_VIRTUAL_NETWORK_SECURITY_GROUP_SECURITY_RULE_RESOURCE_TYPE : {
-        "apiVersion" : "2019-04-01",
-        "type" : "Microsoft.Network/networkSecurityGroups/securityRules",
-        "conditions" : []
-      },
-      AZURE_NETWORK_WATCHER_RESOURCE_TYPE : {
-        "apiVersion" : "2019-04-01",
-        "type" : "Microsoft.Network/networkWatchers",
-        "conditions" : []
-      }
-    }
+[#assign networkResourceProfiles = {
+  AZURE_APPLICATION_SECURITY_GROUP_RESOURCE_TYPE : {
+    "apiVersion" : "2019-04-01",
+    "type" : "Microsoft.Network/applicationSecurityGroups"
+  },
+  AZURE_ROUTE_TABLE_RESOURCE_TYPE : {
+    "apiVersion" : "2019-02-01",
+    "type" : "Microsoft.Network/routeTables"
+  },
+  AZURE_ROUTE_TABLE_ROUTE_RESOURCE_TYPE : {
+    "apiVersion" : "2019-02-01",
+    "type" : "Microsoft.Network/routeTables/routes"
+  },
+  AZURE_SERVICE_ENDPOINT_POLICY_RESOURCE_TYPE : {
+    "apiVersion" : "2019-02-01",
+    "type" : "Microsoft.Network/serviceEndpointPolicies"
+  },
+  AZURE_SERVICE_ENDPOINT_POLICY_DEFINITION_RESOURCE_TYPE : {
+    "apiVersion" : "2019-02-01",
+    "type" : "Microsoft.Network/serviceEndpointPolicies/serviceEndpointPolicyDefinitions"
+  },
+  AZURE_SUBNET_RESOURCE_TYPE : {
+    "apiVersion" : "2019-02-01",
+    "type" : "Microsoft.Network/virtualNetworks/subnets"
+  },
+  AZURE_VIRTUAL_NETWORK_RESOURCE_TYPE : {
+    "apiVersion" : "2019-02-01",
+    "type" : "Microsoft.Network/virtualNetworks"
+  },
+  AZURE_VIRTUAL_NETWORK_PEERING_RESOURCE_TYPE : {
+    "apiVersion" : "2019-02-01",
+    "type" : "Microsoft.Network/virtualNetworks/virtualNetworkPeerings"
+  },
+  AZURE_VIRTUAL_NETWORK_SECURITY_GROUP_RESOURCE_TYPE : {
+    "apiVersion" : "2019-02-01",
+    "type" : "Microsoft.Network/networkSecurityGroups"
+  },
+  AZURE_VIRTUAL_NETWORK_SECURITY_GROUP_SECURITY_RULE_RESOURCE_TYPE : {
+    "apiVersion" : "2019-04-01",
+    "type" : "Microsoft.Network/networkSecurityGroups/securityRules"
+  },
+  AZURE_NETWORK_WATCHER_RESOURCE_TYPE : {
+    "apiVersion" : "2019-04-01",
+    "type" : "Microsoft.Network/networkWatchers"
   }
-]
+}]
+
+[#list networkResourceProfiles as resource,attributes]
+  [@addResourceProfile
+      service=AZURE_NETWORK_SERVICE
+      resource=resource
+      profile=
+          {
+              "apiVersion" : attributes.apiVersion,
+              "type" : attributes.type
+          }
+  /]
+[/#list]
 
 [#assign VIRTUAL_NETWORK_OUTPUT_MAPPINGS = 
   {

--- a/services/microsoft.storage/resource.ftl
+++ b/services/microsoft.storage/resource.ftl
@@ -5,15 +5,18 @@
         AZURE_STORAGE_SERVICE : {
             AZURE_STORAGEACCOUNT_RESOURCE_TYPE : {
                 "apiVersion" : "2019-04-01",
-                "type" : "Microsoft.Storage/storageAccounts"
+                "type" : "Microsoft.Storage/storageAccounts",
+                "conditions" : [ "name_to_lower" ] [#-- TODO: Impliment conditions, and add resourceId() functionality --]
             },
             AZURE_BLOBSERVICE_RESOURCE_TYPE : {
                 "apiVersion" : "2019-04-01",
-                "type" : "Microsoft.Storage/storageAccounts/blobServices"
+                "type" : "Microsoft.Storage/storageAccounts/blobServices",
+                "conditions" : [ "parent_to_lower" ]
             },
             AZURE_BLOBSERVICE_CONTAINER_RESOURCE_TYPE : {
                 "apiVersion" : "2019-04-01",
-                "type" : "Microsoft.Storage/storageAccounts/blobServices/containers"
+                "type" : "Microsoft.Storage/storageAccounts/blobServices/containers",
+                "conditions" : [ "parent_to_lower" ]
             }
         }
     }

--- a/services/microsoft.storage/resource.ftl
+++ b/services/microsoft.storage/resource.ftl
@@ -196,7 +196,8 @@
     deleteRetentionPolicy={}
     automaticSnapshotPolicyEnabled=false
     resources=[]
-    dependsOn=[]]
+    dependsOn=[]
+    parentNames=[]]
 
     [#assign CORSRules = []]
     [#list CORSBehaviours as behaviour]
@@ -218,6 +219,7 @@
 
     [@armResource
         name=name
+        parentNames=parentNames
         profile=AZURE_BLOBSERVICE_RESOURCE_TYPE
         dependsOn=dependsOn
         resources=resources
@@ -237,10 +239,12 @@
     publicAccess=false
     metadata={}
     resources=[]
-    dependsOn=[]]
+    dependsOn=[]
+    parentNames=[]]
 
     [@armResource
         name=name
+        parentNames=parentNames
         profile=AZURE_BLOBSERVICE_CONTAINER_RESOURCE_TYPE
         resources=resources
         dependsOn=dependsOn

--- a/services/microsoft.storage/resource.ftl
+++ b/services/microsoft.storage/resource.ftl
@@ -1,26 +1,37 @@
 [#ftl]
 
-[#assign azureResourceProfiles +=
-    {
-        AZURE_STORAGE_SERVICE : {
-            AZURE_STORAGEACCOUNT_RESOURCE_TYPE : {
-                "apiVersion" : "2019-04-01",
-                "type" : "Microsoft.Storage/storageAccounts",
-                "conditions" : [ "name_to_lower" ] [#-- TODO: Impliment conditions, and add resourceId() functionality --]
-            },
-            AZURE_BLOBSERVICE_RESOURCE_TYPE : {
-                "apiVersion" : "2019-04-01",
-                "type" : "Microsoft.Storage/storageAccounts/blobServices",
-                "conditions" : [ "parent_to_lower" ]
-            },
-            AZURE_BLOBSERVICE_CONTAINER_RESOURCE_TYPE : {
-                "apiVersion" : "2019-04-01",
-                "type" : "Microsoft.Storage/storageAccounts/blobServices/containers",
-                "conditions" : [ "parent_to_lower" ]
-            }
+[@addResourceProfile
+    service=AZURE_STORAGE_SERVICE
+    resource=AZURE_STORAGEACCOUNT_RESOURCE_TYPE
+    profile=
+        {
+            "apiVersion" : "2019-04-01",
+            "type" : "Microsoft.Storage/storageAccounts",
+            "conditions" : [ "name_to_lower" ]
         }
-    }
-]
+/]
+
+[@addResourceProfile
+    service=AZURE_STORAGE_SERVICE
+    resource=AZURE_BLOBSERVICE_RESOURCE_TYPE
+    profile=
+        {
+            "apiVersion" : "2019-04-01",
+            "type" : "Microsoft.Storage/storageAccounts/blobServices",
+            "conditions" : [ "parent_to_lower" ]
+        }
+/]
+
+[@addResourceProfile
+    service=AZURE_STORAGE_SERVICE
+    resource=AZURE_BLOBSERVICE_CONTAINER_RESOURCE_TYPE
+    profile=
+        {
+            "apiVersion" : "2019-04-01",
+            "type" : "Microsoft.Storage/storageAccounts/blobServices/containers",
+            "conditions" : [ "parent_to_lower" ]
+        }
+/]
 
 [#assign STORAGE_ACCOUNT_OUTPUT_MAPPINGS =
     {

--- a/services/microsoft.storage/resource.ftl
+++ b/services/microsoft.storage/resource.ftl
@@ -206,12 +206,12 @@
 
 [#macro createBlobService
     name
+    accountId
     CORSBehaviours=[]
     deleteRetentionPolicy={}
     automaticSnapshotPolicyEnabled=false
     resources=[]
-    dependsOn=[]
-    parentNames=[]]
+    dependsOn=[]]
 
     [#assign CORSRules = []]
     [#list CORSBehaviours as behaviour]
@@ -233,7 +233,7 @@
 
     [@armResource
         name=name
-        parentNames=parentNames
+        parentNames=[accountId]
         profile=AZURE_BLOBSERVICE_RESOURCE_TYPE
         dependsOn=dependsOn
         resources=resources
@@ -250,15 +250,16 @@
 
 [#macro createBlobServiceContainer
     name
+    accountId
+    blobId
     publicAccess=false
     metadata={}
     resources=[]
-    dependsOn=[]
-    parentNames=[]]
+    dependsOn=[]]
 
     [@armResource
         name=name
-        parentNames=parentNames
+        parentNames=[accountId, blobId]
         profile=AZURE_BLOBSERVICE_CONTAINER_RESOURCE_TYPE
         resources=resources
         dependsOn=dependsOn

--- a/services/resource.ftl
+++ b/services/resource.ftl
@@ -76,15 +76,8 @@ Id of a resource within the same template, only the resourceId is necessary.
 --]
 [#function formatAzureResourceName name parentNames=[]]
 
-    [#local nameSegments = []]
-    
-    [#list parentNames as segment]
-        [#local nameSegments += [segment]]
-    [/#list]
-    [#local nameSegments += [name]]
-
-    [#if nameSegments?size gt 1]
-        [#return nameSegments?join("/")]
+    [#if parentNames?has_content]
+        [#return formatRelativePath( (parentNames![]), name) ]
     [#else]
         [#return name]
     [/#if]

--- a/services/resource.ftl
+++ b/services/resource.ftl
@@ -2,6 +2,41 @@
 
 [#-- Azure Resource Profiles --]
 [#assign azureResourceProfiles = {}]
+[#assign azureResourceProfilesConfiguration = 
+    {
+        "Properties" : [
+            {
+                "Type" : "",
+                "Value" : "Attributes of a Resource Profile."
+            }
+        ],
+        "Attributes" : [
+            {
+                "Names" : "type",
+                "Type" : STRING_TYPE,
+                "Mandatory" : true
+            },
+            {
+                "Names" : "apiVersion",
+                "Type" : STRING_TYPE,
+                "Mandatory" : true
+            },
+            {
+                "Names" : "conditions",
+                "Type" : ARRAY_OF_STRING_TYPE,
+                "Default" : []
+            }
+        ]
+    }
+]
+
+[#macro addResourceProfile service resource profile]
+    [@internalMergeResourceProfiles
+        service=service
+        resource=resource
+        profile=profile
+    /]
+[/#macro]
 
 [#-- Formats a given resourceId into an azure resourceId lookup function.
 The scope of the lookup is dependant on the attributes provided. For the
@@ -225,3 +260,21 @@ can be referenced via dot notation. --]
             inRegion)
     ]
 [/#function]
+
+[#-------------------------------------------------------
+-- Internal support functions for resource processing --
+---------------------------------------------------------]
+
+[#macro internalMergeResourceProfiles service resource profile]
+    [#if profile?has_content ]
+        [#assign azureResourceProfiles = 
+            mergeObjects(
+                azureResourceProfiles,
+                { service : { resource : getCompositeObject(
+                    azureResourceProfilesConfiguration.Attributes,
+                    profile
+                )}} 
+            )
+        ]
+    [/#if]
+[/#macro]


### PR DESCRIPTION
This PR extends the resourceProfile functionality established in #33. It adds the idea of resource conditions, which will allow for manipulation of the resource object in a number of places. 

An example that has been implemented in this PR is where a resource requires a lowercase name. Storage Accounts in azure have strict naming requirements. Here we can list those requirements in an array at the profile level, then the resource is created as normal without having to factor in extra processing for the lower case name . Immediately before either the resource is created (or during the referencing of its attributes), the conditions are all processed on the resource, then it is added to the output json. In this way, we can easily re-use similar requirements for future resources by including the appropriate condition to its profile.

Also implemented are some corrections to the Outputs. 

- Outputs were merging under the same name which resulted in an incorrect number of them (they merged). This has been resolved by making use of the ParentNames attribute.
- Outputs had not factored into account that we often only want a single string rather than a full object to be output. This is now working as intended and both options are available.