### PR TITLE
Allow Zones attribute on armResource.

### DIFF
--- a/deploymentframeworks/arm/output.ftl
+++ b/deploymentframeworks/arm/output.ftl
@@ -93,6 +93,7 @@
     sku={}
     kind=""
     plan={}
+    zones=[]
     resources=[]
     parentNames=[]
     outputs={}]
@@ -137,6 +138,7 @@
             attributeIfContent("sku", sku) +
             attributeIfContent("kind", kind) +
             attributeIfContent("plan", plan) +
+            attributeIfContent("zones", zones) +
             attributeIfContent("resources", resources)
         ]
     /]


### PR DESCRIPTION
This PR enables the use of the Zones attribute, which will soon be utilised by the Bastion component