### PR TITLE
Feat component gateway

### DIFF
--- a/components/gateway/id.ftl
+++ b/components/gateway/id.ftl
@@ -1,0 +1,22 @@
+[#ftl]
+[@addResourceGroupInformation
+  type=NETWORK_GATEWAY_COMPONENT_TYPE
+  attributes=[]
+  provider=AZURE_PROVIDER
+  resourceGroup=DEFAULT_RESOURCE_GROUP
+  services=
+    [
+      AZURE_NETWORK_SERVICE
+    ]
+/]
+
+[@addResourceGroupInformation
+  type=NETWORK_GATEWAY_DESTINATION_COMPONENT_TYPE
+  attributes=[]
+  provider=AZURE_PROVIDER
+  resourceGroup=DEFAULT_RESOURCE_GROUP
+  services=
+    [
+      AZURE_NETWORK_SERVICE
+    ]
+/]

--- a/components/gateway/setup.ftl
+++ b/components/gateway/setup.ftl
@@ -1,0 +1,83 @@
+[#ftl]
+
+[#macro azure_gateway_arm_segment occurrence]
+
+  [#if deploymentSubsetRequired("genplan", false)]
+    [@addDefaultGenerationPlan subsets="template" /]
+    [#return]
+  [/#if]
+
+  [#local gwCore = occurrence.Core]
+  [#local gwSolution = occurrence.Configuration.Solution]
+  [#local gwResources = occurrence.State.Resources]
+
+  [#local occurrenceNetwork = getOccurrenceNetwork(occurrence) ]
+  [#local networkLink = occurrenceNetwork.Link!{} ]
+
+  [#if !networkLink?has_content]
+    [@fatal
+      message="Tier Network configuration incomplete"
+      context=
+        {
+          "networkTier" : occurrenceNetwork,
+          "Link" : networkLink
+        }
+    /]
+  [/#if]
+
+  [#local networkLinkTarget = getLinkTarget(occurrence, networkLink, false) ]
+  [#if ! networkLinkTarget?has_content ]
+    [@fatal message="Network could not be found" context=networkLink /]
+  [/#if]
+  [#local networkResources = networkLinkTarget.State.Resources]
+
+  [#local sourceIPAddressGroups = gwSolution.SourceIPAddressGroups]
+  [#local sourceCidrs = getGroupCIDRs(sourceIPAddressGroups, true, occurrence)]
+
+  [#-- Private DNS Zone Creation --]
+  [#if deploymentSubsetRequired(NETWORK_GATEWAY_COMPONENT_TYPE, true)]
+
+    [@createPrivateDnsZone 
+      id=gwResources["dnsZone"].Id 
+      name=gwResources["dnsZone"].Name
+      location=regionId
+    /]
+
+    [@createPrivateDnsZoneVnetLink 
+      id=gwResources["vnetLink"].Id
+      name=gwResources["vnetLink"].Name
+      location=regionId
+      vnetId=networkResources["vnet"].Id
+    /]
+
+  [/#if]
+
+  [#list occurrence.Occurrences![] as subOccurrence]
+
+    [@debug message="Suboccurrence" context=subOccurrence enabled=false /]
+
+    [#local core = subOccurrence.Core]
+    [#local solution = subOccurrence.Configuration.Solution]
+    [#local resources = subOccurrence.State.Resources]
+
+    [#switch gwSolution.Engine]
+      [#case "vpcendpoint"]
+        [#local privateEndpointResources = resources["privateEndpoints"]!{}]
+        [#if deploymentSubsetRequired(NETWORK_GATEWAY_COMPONENT_TYPE, true)]
+          [#list privateEndpointResources as privateEndpointId, privateEndpoint]
+            
+            [@createPrivateEndpoint
+              id=privateEndpoint.Id
+              name=privateEndpoint.Name
+              location=regionId
+              subnetId=""
+              privateLinkServiceConnections=[]
+            /]
+
+          [/#list]
+        [/#if]
+        [#break]
+    [/#switch]
+
+  [/#list]
+[/#macro]

--- a/components/gateway/state.ftl
+++ b/components/gateway/state.ftl
@@ -1,0 +1,103 @@
+[#ftl]
+
+[#macro azure_gateway_arm_state occurrence parent={} baseState={}]
+
+  [#local core = occurrence.Core]
+  [#local solution = occurrence.Configuration.Solution]
+  [#local engine = solution.Engine ]
+ 
+  [#if engine == "vpcendpoint"]
+    [#-- 
+      A private DNS Zone is required so we can force routing to the endpoint to remain within the
+      VNet. If we don't then default routing may send traffic via the Internet.
+    --]
+
+    [#assign componentState =
+      {
+        "Resources" : {
+          "dnsZone" : {
+            "Id" : formatDependentResourceId(AZURE_PRIVATE_DNS_ZONE_RESOURCE_TYPE, core.Id),
+            "Name" : formatName(AZURE_PRIVATE_DNS_ZONE_RESOURCE_TYPE, core.TypedName),
+            "Type" : AZURE_PRIVATE_DNS_ZONE_RESOURCE_TYPE
+          },
+          "vnetLink" : {
+            "Id" : formatDependentResourceId(AZURE_PRIVATE_DNS_ZONE_VNET_LINK_RESOURCE_TYPE, core.Id),
+            "Name" : formatName(AZURE_PRIVATE_DNS_ZONE_VNET_LINK_RESOURCE_TYPE, core.Id),
+            "Type" : AZURE_PRIVATE_DNS_ZONE_VNET_LINK_RESOURCE_TYPE
+          }
+        },
+        "Attributes" : {},
+        "Roles" : {
+          "Inbound" : {},
+          "Outbound" : {}
+        }
+      }
+    ]
+      
+  [#else]
+    [@fatal
+      message="Unknown Engine Type"
+      context=occurrence.Configuration.Solution
+    /]
+  [/#if]
+
+[/#macro]
+
+[#macro azure_gatewaydestination_arm_state occurrence parent={} baseState={}]
+  [#local core = occurrence.Core]
+  [#local solution = occurrence.Configuration.Solution]
+
+  [#local parentCore = parent.Core]
+  [#local parentSolution = parent.Configuration.Solution]
+  [#local engine = parentSolution.Engine]
+
+  [#local resources = {}]
+
+  [#if engine == "vpcendpoint"]
+
+    [#local networkEndpoints = getNetworkEndpoints(solution.NetworkEndpointGroups, "a", region)]
+      
+    [#list networkEndpoints as id, networkEndpoint]
+
+      [#local resources = mergeObjects(resources,
+        {
+          "endpointPolicy" : {
+            "Id" : formatResourceId(AZURE_SERVICE_ENDPOINT_POLICY_RESOURCE_TYPE, id),
+            "Name" : formatName(AZURE_SERVICE_ENDPOINT_POLICY_RESOURCE_TYPE, id),
+            "Type" : AZURE_SERVICE_ENDPOINT_POLICY_RESOURCE_TYPE
+          },
+          "endpointPolicyDefinitions" : {
+            id : {
+              "Id" : formatDependentResourceId(AZURE_SERVICE_ENDPOINT_POLICY_DEFINITION_RESOURCE_TYPE, core.Id, replaceAlphaNumericOnly(id, "X")),
+              "Name" : formatName(AZURE_SERVICE_ENDPOINT_POLICY_DEFINITION_RESOURCE_TYPE, id),
+              "EndpointType" : networkEndpoint.Type?lower_case,
+              "ServiceName" : networkEndpoint.ServiceName,
+              "Type" : AZURE_SERVICE_ENDPOINT_POLICY_DEFINITION_RESOURCE_TYPE
+            }
+          }
+        }
+      )]
+
+    [/#list]
+
+    [#assign componentState =
+      {
+        "Resources" : resources,
+        "Attributes" : {
+          "Engine" : parentSolution.Engine
+        },
+        "Roles" : {
+          "Inbound" : {},
+          "Outbound" : {}
+        }
+      }
+    ]
+
+  [#else]
+    [@fatal
+        message="Unknown Engine Type"
+        context=occurrence.Configuration.Solution
+    /]
+  [/#if]
+
+[/#macro]

--- a/components/gateway/state.ftl
+++ b/components/gateway/state.ftl
@@ -17,7 +17,7 @@
         "Resources" : {
           "dnsZone" : {
             "Id" : formatDependentResourceId(AZURE_PRIVATE_DNS_ZONE_RESOURCE_TYPE, core.Id),
-            "Name" : formatName(AZURE_PRIVATE_DNS_ZONE_RESOURCE_TYPE, core.TypedName),
+            "Name" : AZURE_PRIVATE_DNS_ZONE_RESOURCE_TYPE,
             "Type" : AZURE_PRIVATE_DNS_ZONE_RESOURCE_TYPE
           },
           "vnetLink" : {
@@ -59,24 +59,13 @@
       
     [#list networkEndpoints as id, networkEndpoint]
 
-      [#local resources = mergeObjects(resources,
-        {
-          "endpointPolicy" : {
-            "Id" : formatResourceId(AZURE_SERVICE_ENDPOINT_POLICY_RESOURCE_TYPE, id),
-            "Name" : formatName(AZURE_SERVICE_ENDPOINT_POLICY_RESOURCE_TYPE, id),
-            "Type" : AZURE_SERVICE_ENDPOINT_POLICY_RESOURCE_TYPE
-          },
-          "endpointPolicyDefinitions" : {
-            id : {
-              "Id" : formatDependentResourceId(AZURE_SERVICE_ENDPOINT_POLICY_DEFINITION_RESOURCE_TYPE, core.Id, replaceAlphaNumericOnly(id, "X")),
-              "Name" : formatName(AZURE_SERVICE_ENDPOINT_POLICY_DEFINITION_RESOURCE_TYPE, id),
-              "EndpointType" : networkEndpoint.Type?lower_case,
-              "ServiceName" : networkEndpoint.ServiceName,
-              "Type" : AZURE_SERVICE_ENDPOINT_POLICY_DEFINITION_RESOURCE_TYPE
-            }
-          }
-        }
-      )]
+      [#switch networkEndpoint.Type]
+        [#case "Interface"]
+          [#break]
+        [#case "PrivateLink"]
+          [#-- TODO(rossmurr4y): impliment Azure Private Links --]
+          [#break]
+      [/#switch] 
 
     [/#list]
 

--- a/components/network/state.ftl
+++ b/components/network/state.ftl
@@ -76,8 +76,8 @@
     {
       "Resources" : {
         "vnet" : {
-          "Id" : vnetId,
-          "Name" : vnetName,
+          "Id" : formatResourceId(AZURE_VIRTUAL_NETWORK_RESOURCE_TYPE, core.FullName),
+          "Name" : formatName(AZURE_VIRTUAL_NETWORK_RESOURCE_TYPE, core.FullName),
           "Address" : networkAddress + "/" + networkMask,
           "Type" : AZURE_VIRTUAL_NETWORK_RESOURCE_TYPE
         },

--- a/components/network/state.ftl
+++ b/components/network/state.ftl
@@ -76,8 +76,8 @@
     {
       "Resources" : {
         "vnet" : {
-          "Id" : formatResourceId(AZURE_VIRTUAL_NETWORK_RESOURCE_TYPE, core.FullName),
-          "Name" : formatName(AZURE_VIRTUAL_NETWORK_RESOURCE_TYPE, core.FullName),
+          "Id" : vnetId,
+          "Name" : vnetName,
           "Address" : networkAddress + "/" + networkMask,
           "Type" : AZURE_VIRTUAL_NETWORK_RESOURCE_TYPE
         },

--- a/inputsources/shared/masterdata.ftl
+++ b/inputsources/shared/masterdata.ftl
@@ -22,6 +22,19 @@
             }
           },
           "Accounts": {}
+        },
+        "global": {
+          "Partitian": "azure",
+          "Locality": "UnitedStates",
+          "Zones": {
+            "a": {
+              "Title": "Global",
+              "Description": "A Global Zone",
+              "AzureId": "global",
+              "NetworkEndpoints": []
+            }
+          },
+          "Accounts": {}
         }
       },
       "Tiers": {

--- a/services/microsoft.network/resource.ftl
+++ b/services/microsoft.network/resource.ftl
@@ -44,6 +44,14 @@
   AZURE_NETWORK_WATCHER_RESOURCE_TYPE : {
     "apiVersion" : "2019-04-01",
     "type" : "Microsoft.Network/networkWatchers"
+  },
+  AZURE_PRIVATE_DNS_ZONE_RESOURCE_TYPE : {
+    "apiVersion" : "2018-09-01",
+    "type" : "Microsoft.Network/privateDnsZones"
+  },
+  AZURE_PRIVATE_DNS_ZONE_VNET_LINK_RESOURCE_TYPE : {
+    "apiVersion" : "2018-09-01",
+    "type" : "Microsoft.Network/privateDnsZones/virtualNetworkLinks"
   }
 }]
 
@@ -456,6 +464,47 @@
     outputs=outputs
     dependsOn=dependsOn
   /]
+[/#macro]
+
+[#macro createPrivateDnsZone
+  id
+  name
+  location]
+  
+  [@armResource
+    id=id
+    name=name
+    profile=AZURE_PRIVATE_DNS_ZONE_RESOURCE_TYPE
+    location=location
+    properties={}
+  /]
+[/#macro]
+
+[#macro createPrivateDnsZoneVnetLink
+  id
+  name
+  location
+  vnetId
+  autoRegistrationEnabled=false]
+
+  [@armResource
+    id=id
+    name=name
+    profile=AZURE_PRIVATE_DNS_ZONE_VNET_LINK_RESOURCE_TYPE
+    location=location
+    properties=
+      {
+        "virtualNetwork" : {
+          "id" : vnetId
+        } +
+        attributeIfTrue(
+          "registrationEnabled",
+          autoRegistrationEnabled,
+          autoRegistrationEnabled
+        )
+      }
+  /]
+
 [/#macro]
 
 [#-- 

--- a/services/microsoft.network/resource.ftl
+++ b/services/microsoft.network/resource.ftl
@@ -468,14 +468,13 @@
 
 [#macro createPrivateDnsZone
   id
-  name
-  location]
+  name]
   
   [@armResource
     id=id
     name=name
     profile=AZURE_PRIVATE_DNS_ZONE_RESOURCE_TYPE
-    location=location
+    location="global"
     properties={}
   /]
 [/#macro]
@@ -483,7 +482,6 @@
 [#macro createPrivateDnsZoneVnetLink
   id
   name
-  location
   vnetId
   autoRegistrationEnabled=false]
 
@@ -491,7 +489,7 @@
     id=id
     name=name
     profile=AZURE_PRIVATE_DNS_ZONE_VNET_LINK_RESOURCE_TYPE
-    location=location
+    location="global"
     properties=
       {
         "virtualNetwork" : {


### PR DESCRIPTION
This PR implements & closes #26 

The Gateway component in its current MVP state (without privateEndpoints but with publicEndpoints) does not deploy any resources. As discussed in #26 many of the standard resources that would make up a Gateway component within Azure are handled behind the scenes by MSFT. Additionally, there were a number of requirements for some resources to be made alongside Subnet's within the Network component, so they have been migrated to that instead.

As such, the Gateway component currently stands as both a flag to alert CodeOnTap that the Gateway has been accounted for and also as the skeleton state/setup files that will be required for the later implementation of privateEndpoints.

Example generated template:

```
{
  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
  "contentVersion": "1.0.0.0",
  "parameters": {},
  "variables": {},
  "resources": {},
  "outputs": {
    "Subscription": {
      "type": "string",
      "value": "[subscription().id]"
    },
    "ResourceGroup": {
      "type": "string",
      "value": "[resourceGroup().id]"
    },
    "Region": {
      "type": "string",
      "value": "[resourceGroup().location]"
    },
    "DeploymentUnit": {
      "type": "string",
      "value": "vpcendpoint"
    },
    "DeploymentMode": {
      "type": "string",
      "value": "update"
    }
  }
}
```