### PR TITLE
Fix az stackoutput

### DIFF
--- a/inputsources/composite/stackoutput.ftl
+++ b/inputsources/composite/stackoutput.ftl
@@ -25,9 +25,9 @@
         [#list rawStackOutput["properties"] as propertyId, propertyValue]
           [#if propertyId == "outputs"]
 
-            [#list propertyValue as outputId, outputValue]
+            [#local stackOutput = {}]
 
-              [#local stackOutput = {}]
+            [#list propertyValue as outputId, outputValue]
 
               [#switch outputId]
                 [#case "deploymentUnit"]
@@ -38,7 +38,7 @@
                   [#break]
                 [#case "subscription"]
                   [#-- convert Azure languague "subscription to COT language "Account" --]
-                [#local stackOutput += { "Account" : outputValue["value"] }]
+                  [#local stackOutput += { "Account" : outputValue["value"] }]
                   [#break]
                 [#default]
                   [#local stackOutput += { outputId : outputValue["value"] }]
@@ -52,16 +52,11 @@
           [#if stackOutput?has_content]
             [#local stackOutputs += [mergeObjects( { "Level" : level} , stackOutput)]]
           [/#if]
-
         [/#list]
-
       [/#if]
-
-
-      
     [/#list]
   [/#list]
 
   [@addStackOutputs stackOutputs /]
-[@debug message="StackOutputs" context=stackOutputs enabled=true /]
+
 [/#macro]

--- a/inputsources/composite/stackoutput.ftl
+++ b/inputsources/composite/stackoutput.ftl
@@ -11,7 +11,7 @@
   ]
 [/#function]
 
-[#macro azure_input_composite_stackoutput_seed]
+[#macro azure_input_composite_stackoutput_seed id="" deploymentUnit="" level="" region="" account=""]
 
   [#local stackOutputs = []]
 
@@ -19,25 +19,49 @@
   [#list commandLineOptions.Composites.StackOutputs as stackOutputFile]
 
     [#local level = ((stackOutputFile["FileName"])?split('-'))[0]]
+
     [#list (stackOutputFile["Content"]![]) as rawStackOutput]
-      [#if (rawStackOutput["properties"]["outputs"]!{})?has_content]
+      [#if (rawStackOutput["properties"]!{})?has_content]
+        [#list rawStackOutput["properties"] as propertyId, propertyValue]
+          [#if propertyId == "outputs"]
 
-        [#local stackOutput = {
-          "Level" : level
-        }]
+            [#list propertyValue as outputId, outputValue]
 
-        [#list rawStackOutput["properties"]["outputs"] as outputId, outputValue]   
-          [#local stackOutput += {
-            outputId : outputValue.value
-          }]
+              [#local stackOutput = {}]
+
+              [#switch outputId]
+                [#case "deploymentUnit"]
+                  [#local stackOutput += { "DeploymentUnit" : outputValue["value"] }]
+                  [#break]
+                [#case "region"]
+                  [#local stackOutput += { "Region" : outputValue["value"] }]
+                  [#break]
+                [#case "subscription"]
+                  [#-- convert Azure languague "subscription to COT language "Account" --]
+                [#local stackOutput += { "Account" : outputValue["value"] }]
+                  [#break]
+                [#default]
+                  [#local stackOutput += { outputId : outputValue["value"] }]
+                  [#break]
+              [/#switch]
+
+            [/#list]
+
+          [/#if]
+
+          [#if stackOutput?has_content]
+            [#local stackOutputs += [mergeObjects( { "Level" : level} , stackOutput)]]
+          [/#if]
+
         [/#list]
 
-        [#local stackOutputs += [ stackOutput ]]
-
       [/#if]
+
+
+      
     [/#list]
   [/#list]
 
   [@addStackOutputs stackOutputs /]
-
+[@debug message="StackOutputs" context=stackOutputs enabled=true /]
 [/#macro]


### PR DESCRIPTION
This PR introduces a minor fix to take the stack output names that Azure requires which use camelCase on their keys, to Capitalised keys that are mandatory for CodeOnTap. For example a Region output is mandatory, however Azure will output that as "region".