### PR TITLE
Refactor of Baseline Component Keyvault implementation

### DIFF
--- a/components/baseline/state.ftl
+++ b/components/baseline/state.ftl
@@ -84,17 +84,10 @@
 
       [#local resources +=
         {
-          LOCAL_CMK_KEY_PAIR_RESOURCE_TYPE : {
-            "Id" : formatResourceId(LOCAL_CMK_KEY_PAIR_RESOURCE_TYPE, core.Id),
-            "Name" : formatName(LOCAL_CMK_KEY_PAIR_RESOURCE_TYPE, core.SubComponent.Id),
-            "PrivateKey" : formatName(".azure", accountObject.Id, regionId, "cmk", "prv") + ".pem",
-            "PublicKey" : formatName(".azure", accountObject.Id, regionId, "cmk", "crt") + ".pem",
-            "Type" : LOCAL_CMK_KEY_PAIR_RESOURCE_TYPE
-          },
-          AZURE_CMK_KEY_PAIR_RESOURCE_TYPE : {
-            "Id" : formatResourceId(AZURE_CMK_KEY_PAIR_RESOURCE_TYPE, core.SubComponent.Id),
-            "Name" : formatName(AZURE_CMK_KEY_PAIR_RESOURCE_TYPE, core.ShortName, "cmk"),
-            "Type" : AZURE_CMK_KEY_PAIR_RESOURCE_TYPE
+          AZURE_CMK_RESOURCE_TYPE : {
+            "Id" : formatResourceId(AZURE_CMK_RESOURCE_TYPE, core.SubComponent.Id),
+            "Name" : formatName(AZURE_CMK_RESOURCE_TYPE, core.ShortName, "cmk"),
+            "Type" : AZURE_CMK_RESOURCE_TYPE
           }
         }
       ]
@@ -102,13 +95,6 @@
     [#case "ssh"]
       [#local resources +=
         {
-          LOCAL_SSH_PRIVATE_KEY_RESOURCE_TYPE : {
-            "Id" : formatResourceId(LOCAL_SSH_PRIVATE_KEY_RESOURCE_TYPE, core.SubComponent.Id),
-            "Name" : formatName(LOCAL_SSH_PRIVATE_KEY_RESOURCE_TYPE, core.ShortName),
-            "PrivateKey" : formatName(".azure", accountObject.Id, regionId, "ssh", "prv") + ".pem",
-            "PublicKey" : formatName(".azure", accountObject.Id, regionId, "ssh", "crt") + ".pem",
-            "Type" : LOCAL_SSH_PRIVATE_KEY_RESOURCE_TYPE
-          },
           AZURE_SSH_PRIVATE_KEY_RESOURCE_TYPE : {
             "Id" : formatResourceId(AZURE_SSH_PRIVATE_KEY_RESOURCE_TYPE, core.SubComponent.Id),
             "Name" : formatName(AZURE_SSH_PRIVATE_KEY_RESOURCE_TYPE, core.ShortName),

--- a/components/baseline/state.ftl
+++ b/components/baseline/state.ftl
@@ -95,10 +95,16 @@
     [#case "ssh"]
       [#local resources +=
         {
-          AZURE_SSH_PRIVATE_KEY_RESOURCE_TYPE : {
+          "vmKeyPair" : {
             "Id" : formatResourceId(AZURE_SSH_PRIVATE_KEY_RESOURCE_TYPE, core.SubComponent.Id),
             "Name" : formatName(AZURE_SSH_PRIVATE_KEY_RESOURCE_TYPE, core.ShortName),
             "Type" : AZURE_SSH_PRIVATE_KEY_RESOURCE_TYPE
+          },
+          "localKeyPair": {
+            "Id" : formatResourceId(LOCAL_SSH_PRIVATE_KEY_RESOURCE_TYPE, core.Id),
+            "PublicKey" : formatName(".azure", accountObject.Id, regionId, core.SubComponent.Name, "crt") + ".pem",
+            "PrivateKey" : formatName(".azure", accountObject.Id, regionId, core.SubComponent.Name, "prv") + ".pem",
+            "Type" : LOCAL_SSH_PRIVATE_KEY_RESOURCE_TYPE
           }
         }
       ]

--- a/inputsources/shared/masterdata.ftl
+++ b/inputsources/shared/masterdata.ftl
@@ -155,7 +155,10 @@
                 },
                 "Keys": {
                   "ssh": {
-                    "Engine": "ssh"
+                    "Engine": "ssh",
+                    "IPAddressGroups": [
+                      "_global"
+                    ]
                   },
                   "cmk": {
                     "Engine": "cmk"

--- a/services/microsoft.keyvault/id.ftl
+++ b/services/microsoft.keyvault/id.ftl
@@ -8,3 +8,4 @@
 [#assign AZURE_CMK_RESOURCE_TYPE = "cmk"]
 
 [#assign AZURE_SSH_PRIVATE_KEY_RESOURCE_TYPE = "sshkey"]
+[#assign LOCAL_SSH_PRIVATE_KEY_RESOURCE_TYPE = "sshPrivKey"]

--- a/services/microsoft.keyvault/id.ftl
+++ b/services/microsoft.keyvault/id.ftl
@@ -5,8 +5,6 @@
 [#assign AZURE_KEYVAULT_SECRET_RESOURCE_TYPE = "secret"]
 [#assign AZURE_KEYVAULT_ACCESS_POLICY_RESOURCE_TYPE = "vaultAccessPolicy"]
 
-[#assign AZURE_CMK_KEY_PAIR_RESOURCE_TYPE = "cmkKeypair"]
-[#assign LOCAL_CMK_KEY_PAIR_RESOURCE_TYPE = "cmkLocalKeypair"]
+[#assign AZURE_CMK_RESOURCE_TYPE = "cmk"]
 
-[#assign AZURE_SSH_PRIVATE_KEY_RESOURCE_TYPE = "sshKeypair"]
-[#assign LOCAL_SSH_PRIVATE_KEY_RESOURCE_TYPE = "sshLocalKeypair"]
+[#assign AZURE_SSH_PRIVATE_KEY_RESOURCE_TYPE = "sshkey"]

--- a/utility.sh
+++ b/utility.sh
@@ -4,47 +4,6 @@
 #
 # This script is designed to be sourced into other scripts
 
-function az_create_pki_credentials() {
-  local dir="$1"; shift
-  local region="$1"; shift
-  local account="$1"; shift
-  local keytype="$1"; shift
-
-  if [[ (! -f "${dir}/azure-${keytype}-crt.pem") &&
-        (! -f "${dir}/azure-${keytype}-prv.pem") &&
-        (! -f "${dir}/.azure-${keytype}-crt.pem") &&
-        (! -f "${dir}/.azure-${keytype}-prv.pem") &&
-        (! -f "${dir}/.azure-${account}-${region}-${keytype}-crt.pem") &&
-        (! -f "${dir}/.azure-${account}-${region}-${keytype}-prv.pem") ]]; then
-      openssl genrsa -out "${dir}/.azure-${account}-${region}-${keytype}-prv.pem.plaintext" 2048 || return $?
-      openssl rsa -in "${dir}/.azure-${account}-${region}-${keytype}-prv.pem.plaintext" -pubout > "${dir}/.azure-${account}-${region}-${keytype}-crt.pem" || return $?
-  fi
-
-  if [[ ! -f "${dir}/.gitignore" ]]; then
-    cat << EOF > "${dir}/.gitignore"
-*.plaintext
-*.decrypted
-*.ppk
-EOF
-  fi
-
-  return 0
-}
-
-function az_delete_pki_credentials() {
-  local dir="$1"; shift
-  local region="$1"; shift
-  local account="$1"; shift
-  local keytype="$1"; shift
-
-  local restore_nullglob="$(shopt -p nullglob)"
-  shopt -s nullglob
-
-  rm -f "${dir}"/.azure-${account}-${region}-${keytype}-crt* "${dir}"/.azure-${account}-${region}-${keytype}-prv*
-
-  ${restore_nullglob}
-}
-
 # -- Keys --
 
 function az_check_key_credentials() {
@@ -63,17 +22,6 @@ function az_show_key_credentials() {
   local keyId="https://${vaultName}.azure.net/keys/${keyName}"
 
   az keyvault key show --id "${keyId}"
-}
-
-function az_update_key_credentials() {
-  local vaultName="$1"; shift
-  local keyName="$1"; shift
-  local crt_file="$1"; shift
-
-  local crt_content=$(dos2unix < "${crt_file}" | awk 'BEGIN {RS="\n"} /^[^-]/ {printf $1}')
-  ${crt_content} > ${crt_file}
-
-  az keyvault key import --pem-file "${crt_file}" --vault-name "${vaultName}" --name "${keyName}"
 }
 
 function az_delete_key_credentials() {

--- a/utility.sh
+++ b/utility.sh
@@ -5,14 +5,26 @@
 # This script is designed to be sourced into other scripts
 
 # -- Keys --
+function az_create_pki_credentials() {
+  local dir="$1"; shift
+  local region="$1"; shift
+  local account="$1"; shift
+  local keytype="$1"; shift
 
-function az_check_key_credentials() {
-  local vaultName="$1"; shift
-  local keyName="$1"; shift
+  if [[ ! -f "${dir}/.azure-${account}-${region}-${keytype}-crt.pem" ]]; then
+      openssl genrsa -out "${dir}/.azure-${account}-${region}-${keytype}-prv.pem.plaintext" 2048 || return $?
+      openssl rsa -in "${dir}/.azure-${account}-${region}-${keytype}-prv.pem.plaintext" -pubout > "${dir}/.azure-${account}-${region}-${keytype}-crt.pem" || return $?
+  fi
 
-  local keyId="https://${vaultName}.azure.net/keys/${keyName}"
+  if [[ ! -f "${dir}/.gitignore" ]]; then
+    cat << EOF > "${dir}/.gitignore"
+*.plaintext
+*.decrypted
+*.ppk
+EOF
+  fi
 
-  az keyvault key show --id "${keyId}" 2>&1 > /dev/null
+  return 0
 }
 
 function az_show_key_credentials() {
@@ -24,15 +36,38 @@ function az_show_key_credentials() {
   az keyvault key show --id "${keyId}"
 }
 
-function az_delete_key_credentials() {
+# -- Secrets --
+function az_add_secret() {
+  local vaultName="$1"; shift
+  local keyName="$1"; shift
+  local secret="$1"; shift
+
+  info "Adding secret ${secret} to vault ${vaultName} ..."
+  if [[ -f ${secret} ]]; then
+    az keyvault secret set --vault-name "${vaultName}" --name "${keyName}" --file "${secret}" 2>&1 > /dev/null
+  else
+    az keyvault secret set --vault-name "${vaultName}" --name "${keyName}" --value "${secret}" 2>&1 > /dev/null
+  fi
+}
+
+function az_check_secret() {
+  local vaultName="$1"; shift
+  local secretName="$1"; shift
+
+  local secretId="https://${vaultName}.vault.azure.net/secrets/${secretName}"
+
+  az keyvault secret show --id "${secretId}" > /dev/null
+}
+
+function az_delete_secret() {
   local vaultName="$1"; shift
   local keyName="$1"; shift
 
-  local keyId="https://${vaultName}.azure.net/keys/${keyName}"
+  local keyId="https://${vaultName}.vault.azure.net/keys/${keyName}"
 
   #azure returns a large object upon successful deletion, so we redirect that.
   az keyvault key show --id "${keyId}" 2>&1 > /dev/null && \
-  { az keyvault key delete --id "${keyId}" > /dev/null || return $?; }
+  { az keyvault secret delete --id "${keyId}" > /dev/null || return $?; }
 
   return 0
 }


### PR DESCRIPTION
Baseline keyvault is currently not allowing access from the Azure administrator's group or anyone without changes beyond the scope of the baseline component. This isn't ideal as it prevents codeontap when run to upload/generate any private keys into the vault. This PR implements IPAddressGroups for SSH keys, which defaults to "_global". The Azure implementation of this will then effectively say "all networks can access this keyvault" (permission restrictions remain). This allows the baseline component to run its epilogue scripts and generate applicable keys.

Speaking of keys, this PR also refactors the way the keys are generated. Azure CLI can generate RSA keys directly into Keyvault and doing so means much a much more simplistic epilogue script implementation. 

Due to these significant refactors this PR also removes some now unnecessary resources, variables, utility functions and renames resource types to more accurately reflect how Azure works with keys.