### PR TITLE
created spa component sans cdn interactions.

### DIFF
--- a/components/baseline/state.ftl
+++ b/components/baseline/state.ftl
@@ -64,7 +64,9 @@
           "Type" : AZURE_BLOBSERVICE_CONTAINER_RESOURCE_TYPE
         }
       },
-      "Attributes": {},
+      "Attributes": {
+        "ACCOUNT_NAME" : parent.State.Resources["storageAccount"].Name
+      },
       "Roles": {
         "Inbound": {},
         "Outbound": {}

--- a/components/spa/id.ftl
+++ b/components/spa/id.ftl
@@ -1,0 +1,12 @@
+[#ftl]
+[@addResourceGroupInformation
+    type=SPA_COMPONENT_TYPE
+    attributes=[]
+    provider=AZURE_PROVIDER
+    resourceGroup=DEFAULT_RESOURCE_GROUP
+    services=
+      [
+        AZURE_NETWORK_FRONTDOOR_SERVICE,
+        AZURE_STORAGE_SERVICE
+      ]
+/]

--- a/components/spa/setup.ftl
+++ b/components/spa/setup.ftl
@@ -1,0 +1,157 @@
+[#ftl]
+
+[#macro azure_spa_arm_genplan_application occurrence]
+  [@addDefaultGenerationPlan subsets=["prologue", "config", "epilogue"] /]
+[/#macro]
+
+[#macro azure_spa_arm_setup_application occurrence]
+
+  [@debug message="Entering SPA Setup" context=occurrence enabled=false /]
+
+  [#local core = occurrence.Core ]
+  [#local solution = occurrence.Configuration.Solution ]
+  [#local settings = occurrence.Configuration.Settings ]
+  [#local resources = occurrence.State.Resources]
+
+  [#local fragment = getOccurrenceFragmentBase(occurrence)]
+  [#local baselineLinks = getBaselineLinks(occurrence, [ "OpsData"], false, false)]
+  [#local storageAccount = baselineLinks["OpsData"].State.Attributes["ACCOUNT_NAME"]]
+  [#local baselineComponentIds = getBaselineComponentIds(baselineLinks, "", "", "", "container")]
+  [#local operationsBlobContainer = baselineLinks["OpsData"].State.Resources["container"].Name]
+  [#--[#local operationsBlobContainer = getExistingReference(baselineComponentIds["OpsData"])] --]
+  [#local contextLinks = getLinkTargets(occurrence)]
+
+  [#local distributions = []]
+
+  [#-- SPA Context --]
+  [#assign _context =
+    {
+      "Id" : fragment,
+      "Name" : fragment,
+      "Instance" : core.Instance.Id,
+      "Version" : core.Version.Id,
+      "DefaultEnvironment" : defaultEnvironment(occurrence, contextLinks, baselineLinks),
+      "Environment" : {},
+      "Links" : contextLinks,
+      "BaselineLinks" : baselineLinks,
+      "DefaultCoreVariables" : false,
+      "DefaultEnvironmentVariables" : false,
+      "DefaultLinkVariables" : false,
+      "DefaultBaselineVariables" : false
+    }
+  ]
+
+  [#-- Add in container specifics including override of defaults --]
+  [#local fragmentId = formatFragmentId(_context)]
+  [#-- [#include fragmentList?ensure_starts_with("/")] --]
+
+  [#assign _context += getFinalEnvironment(occurrence, _context)]
+
+  [#list _context.Links as id,linkTarget]
+
+    [#local linkTargetCore = linkTarget.Core]
+    [#local linkTargetConfiguration = linkTarget.Configuration]
+    [#local linkTargetResources = linkTarget.State.Resources]
+    [#local linkTargetAttributes = linkTarget.State.Attributes]
+    [#local linkDirection = linkTarget.Direction]
+
+    [#switch linkTargetCore.Type]
+      [#case CDN_ROUTE_COMPONENT_TYPE]
+        [#if linkDirection == "inbound"]
+          [#local distributions += [ {
+            "DistributionId" : linkTargetAttributes["DISTRIBUTION_ID"],
+            "PathPattern" : linkTargetResources["origin"].PathPattern
+          }]]
+        [/#if]
+        [#break]
+    [/#switch]
+
+  [/#list]
+
+  [#if ! distributions?has_content]
+
+    [#-- TODO(rossmurr4y): add after CDN component is done.
+    [@fatal
+      message="An SPA must have at least 1 CDN Route component link - Add an inbound CDN Route link to the SPA"
+      context=solution
+      enabled=true
+    /]--]
+  [/#if]
+
+  [#if deploymentSubsetRequired("prologue", false)]
+    [#--
+      Prologue Script Order of Operations:
+      1 - Stage the latest build files
+      2 - Unzip/Sync build files with the container
+      3 - Stage the latest config
+      4 - Sync config with the container
+    --]
+    [@addToDefaultBashScriptOutput
+      content=
+        getBuildScript(
+          "spaFiles",
+          "spa",
+          productName,
+          occurrence,
+          "spa.zip"
+        ) +
+        syncFilesToBlobContainerScript(
+          "spaFiles",
+          storageAccount,
+          operationsBlobContainer,
+          formatRelativePath(
+            getOccurrenceSettingValue(occurrence, "SETTINGS_PREFIX"),
+            "spa"
+          )
+        ) +
+        getLocalFileScript(
+          "configFiles",
+          "$\{CONFIG}",
+          "config.json"
+        ) +
+        syncFilesToBlobContainerScript(
+          "configFiles",
+          storageAccount,
+          operationsBlobContainer,
+          formatRelativePath(
+            getOccurrenceSettingValue(occurrence, "SETTINGS_PREFIX"),
+            solution.ConfigPath
+          )
+        )
+    /]
+  [/#if]
+
+  [#-- TODO(rossmurr4y): add when the CDN is implemeted
+  [#if deploymentSubsetRequired("config", false)]
+    [@addToDefaultJsonOutput
+      content={ "RUN_ID" : commandLineOptions.Run.Id } + _context.Environment
+    /]
+  [/#if] --]
+
+  [#-- invalidate the old cached content on the CDN with an epilogue script --]
+  [#-- 
+  [#if solution.InvalidateOnUpdate && distributions?has_content]
+    [#local invalidationScript = []]
+    [#list distributions as distribution]
+
+      TODO(rossmurr4y):
+      once the CDN component exists, revisit this and ensure the cached data is invalidated.
+
+    [/#list]
+  
+    [#if deploymentSubsetRequired("epilogue", false)]    
+      [@addToDefaultBashScriptOutput
+        [
+          "case $\{STACK_OPERATION} in",
+          "  create|update)"
+        ] +
+        invalidationScript +
+        [
+          " ;;",
+          " esac"
+        ]
+      /]
+    [/#if]
+  [/#if]
+  --]
+[/#macro]

--- a/components/spa/state.ftl
+++ b/components/spa/state.ftl
@@ -1,0 +1,40 @@
+[#ftl]
+
+[#macro azure_spa_arm_state occurrence parent={} baseState={}]
+
+  [#local core = occurrence.Core]
+  [#local solution = occurrence.Configuration.Solution]
+
+  [#-- Baseline component lookup --]
+  [#local baselineLinks = getBaselineLinks(occurrence, [ "OpsData" ], false, false )]
+  [#local baselineComponentIds = getBaselineComponentIds(baselineLinks, "cmk", "vmKeyPair", "", "container")]
+  [#local operationsBlobContainer = getExistingReference(baselineComponentIds["OpsData"])]
+  
+  [#local configFilePath = 
+    formatRelativePath(
+      getOccurrenceSettingValue(occurrence, "SETTINGS_PREFIX"),
+      "config")]
+  [#local configFileName = "config.json" ]
+
+  [#assign componentState =
+    {
+      "Resources": {
+        "site": {
+          "Id": formatResourceId(SPA_COMPONENT_TYPE, core.Id),
+          "Deployed": true,
+          "Type": SPA_COMPONENT_TYPE
+        }
+      },
+      "Attributes": {
+        "CONFIG_PATH_PATTERN": solution.ConfigPathPattern,
+        "CONFIG_STORAGE_CONTAINER": operationsBlobContainer,
+        "CONFIG_FILE": formatRelativePath(configFilePath, configFileName)
+      },
+      "Roles": {
+        "Inbound": {},
+        "Outbound": {}
+      }
+    }
+  ]
+
+[/#macro]

--- a/services/microsoft.network.frontdoor/resource.ftl
+++ b/services/microsoft.network.frontdoor/resource.ftl
@@ -199,7 +199,7 @@
       attributeIfContent("frontendEndpoints", frontendEndpoints) +
       attributeIfContent("backendPoolsSettings", {} +
         attributeIfContent("enforceCertificateNameCheck", backendEnforceCertNameCheck) + 
-        attributeIfContent("sendRecvTimeoutSeconds", backendSendRecvTimeoutSeconds")
+        attributeIfContent("sendRecvTimeoutSeconds", backendSendRecvTimeoutSeconds)
       )
   /]
 


### PR DESCRIPTION
Contributes to #59
Contributes to #60  

Establishes the foundations for an SPA component.
Unlike a typical component, the SPA does not generate a template, it instead creates prologue/epilogue shell scripts that when run will stage and sync a Single Paged Application into an Azure Blob Store. This PR implements this.

The final SPA component will address the SPA content that is stored on a CDN - In Azure's case that is the "FrontDoor". The CDN needs to be notified to store the new content and purge the old cached content. This PR does not include this yet as the CDN content is remains in development and as such it does not close the original ticket. Once both CDN and SPA components exist and work together I will close off both PRs.

Example prologue script:
``` sh
#!/usr/bin/env bash
#--COT-RequestReference=unassigned
#--COT-ConfigurationReference=unassigned
#--COT-RunId=tlah7xusp9
az_copy_from_blob "storage-2x5e6zs3h6" "spa" "djankywalks" "${tmpdir}/spa.zip" || return $?
#
addToArray spaFiles "${tmpdir}/spa.zip"
#
case ${STACK_OPERATION} in
delete)
    az_delete_blob_dir "storage-2x5e6zs3h6" "settings/djankywalks/integration/web/maintenance/v1/spa" || return $?
    ;;
create | update)
    debug "FILES=${spaFiles[@]}"
    #
    az_sync_with_blob "storage-2x5e6zs3h6" "container-opsdata" "settings/djankywalks/integration/web/maintenance/v1/spa" "spaFiles" || return $?
    ;;
esac
#
tmp_filename="config.json"
cp "${CONFIG}" "${tmpdir}/${tmp_filename}"
#
addToArray configFiles "${tmpdir}/${tmp_filename}"
#
case ${STACK_OPERATION} in
delete)
    az_delete_blob_dir "storage-2x5e6zs3h6" "settings/djankywalks/integration/web/maintenance/v1/config" || return $?
    ;;
create | update)
    debug "FILES=${configFiles[@]}"
    #
    az_sync_with_blob "storage-2x5e6zs3h6" "container-opsdata" "settings/djankywalks/integration/web/maintenance/v1/config" "configFiles" || return $?
    ;;
esac
```