### PR TITLE
Refactor Output Mappings

### DIFF
--- a/deploymentframeworks/arm/output.ftl
+++ b/deploymentframeworks/arm/output.ftl
@@ -166,28 +166,27 @@
         ]
     /]
 
- [@debug message="outputMappings" context=outputMappings enabled=true /]
     [#list outputMappings as provider,components]
         [#list components as componentType,mappings]
             [#list mappings as attributeType,attributes]
                 [#list attributes as attributeName,attributeValue]
 
                     [#if attributeValue == "id"]
-                        [#local name = id]
+                        [#local outputName = id]
                         [#local type = "string"]
                         [#local value = getReference(id, name)]
                     [#else]
                         [#-- Properties that are "several": { "levels" : { "deep" : {}}} --]
                         [#-- are referenced with a Property value of several.levels.deep --]
                         [#local propertySections = attributeValue?split(".")]
-                        [#local name = formatAttributeId(id, propertySections)]
+                        [#local outputName = formatAttributeId(id, propertySections)]
                         [#local type = attributeValue?is_hash?then("object","string")]
                         [#local typeFull = getAzureResourceProfile(getResourceType(id)).type]
-                        [#local value = getReference(id, name, typeFull, attributeType, "", "")]
+                        [#local value = getReference(id, name, typeFull, attributeType, "", "", attributeValue)]
                     [/#if]
 
                     [@armOutput
-                        name=name
+                        name=outputName
                         type=type
                         value=value
                     /]

--- a/deploymentframeworks/arm/output.ftl
+++ b/deploymentframeworks/arm/output.ftl
@@ -166,31 +166,35 @@
         ]
     /]
 
-    [#list outputs as outputType,outputValue]
-        [@armOutput
-            name=(outputType = REFERENCE_ATTRIBUTE_TYPE)?then(
-                id,
-                formatAttributeId(id, outputType)
-            )
-            type=((outputValue.Property!"")?has_content)?then(
-                "string",
-                (outputType = REFERENCE_ATTRIBUTE_TYPE)?then(
-                    "string",
-                    "object"
-                )
-            )
-            value=getReference(
-                id,
-                name,
-                outputType,
-                "",
-                "",
-                ((outputValue.Property!"")?has_content)?then(
-                    outputValue.Property,
-                    ""
-                )
-            )
-        /]
+ [@debug message="outputMappings" context=outputMappings enabled=true /]
+    [#list outputMappings as provider,components]
+        [#list components as componentType,mappings]
+            [#list mappings as attributeType,attributes]
+                [#list attributes as attributeName,attributeValue]
+
+                    [#if attributeValue == "id"]
+                        [#local name = id]
+                        [#local type = "string"]
+                        [#local value = getReference(id, name)]
+                    [#else]
+                        [#-- Properties that are "several": { "levels" : { "deep" : {}}} --]
+                        [#-- are referenced with a Property value of several.levels.deep --]
+                        [#local propertySections = attributeValue?split(".")]
+                        [#local name = formatAttributeId(id, propertySections)]
+                        [#local type = attributeValue?is_hash?then("object","string")]
+                        [#local typeFull = getAzureResourceProfile(getResourceType(id)).type]
+                        [#local value = getReference(id, name, typeFull, attributeType, "", "")]
+                    [/#if]
+
+                    [@armOutput
+                        name=name
+                        type=type
+                        value=value
+                    /]
+
+                [/#list]
+            [/#list]
+        [/#list]
     [/#list]
 [/#macro]
 

--- a/services/microsoft.compute/resource.ftl
+++ b/services/microsoft.compute/resource.ftl
@@ -10,7 +10,10 @@
     }
 /]
 
-[#assign AZURE_VIRTUALMACHINE_SCALESET_OUTPUT_MAPPINGS = 
+[@addOutputMapping 
+  provider=AZURE_PROVIDER
+  resourceType=AZURE_VIRTUALMACHINE_SCALESET_RESOURCE_TYPE
+  mappings=
   {
     REFERENCE_ATTRIBUTE_TYPE : {
       "Property" : "id"
@@ -19,11 +22,7 @@
       "Property" : "name"
     }
   }
-]
-
-[#assign outputMappings +=
-  { AZURE_VIRTUALMACHINE_SCALESET_RESOURCE_TYPE : AZURE_VIRTUALMACHINE_SCALESET_OUTPUT_MAPPINGS }
-]
+/]
 
 [#function getVirtualMachineProfileLinuxConfigPublicKey
   path

--- a/services/microsoft.insights/resource.ftl
+++ b/services/microsoft.insights/resource.ftl
@@ -10,19 +10,16 @@
     }
 /]
 
-[#assign AZURE_AUTOSCALE_SETTINGS_OUTPUT_MAPPINGS =
+[@addOutputMapping 
+  provider=AZURE_PROVIDER
+  resourceType=AZURE_AUTOSCALE_SETTINGS_RESOURCE_TYPE
+  mappings=
   {
     REFERENCE_ATTRIBUTE_TYPE : {
       "Property" : "id"
     }
   }
-]
-
-[#assign outputMappings += 
-  {
-    AZURE_AUTOSCALE_SETTINGS_RESOURCE_TYPE : AZURE_AUTOSCALE_SETTINGS_OUTPUT_MAPPINGS
-  }
-]
+/]
 
 [#function getAutoScaleRule
   metricName

--- a/services/microsoft.keyvault/resource.ftl
+++ b/services/microsoft.keyvault/resource.ftl
@@ -31,15 +31,21 @@
         }
 /]
 
-[#assign AZURE_KEYVAULT_OUTPUT_MAPPINGS = 
+[@addOutputMapping 
+  provider=AZURE_PROVIDER
+  resourceType=AZURE_KEYVAULT_RESOURCE_TYPE
+  mappings=
   {
     REFERENCE_ATTRIBUTE_TYPE : {
       "Property" : "id"
     }
   }
-]
+/]
 
-[#assign AZURE_KEYVAULT_SECRET_OUTPUT_MAPPINGS =
+[@addOutputMapping 
+  provider=AZURE_PROVIDER
+  resourceType=AZURE_KEYVAULT_SECRET_RESOURCE_TYPE
+  mappings=
   {
     REFERENCE_ATTRIBUTE_TYPE : {
       "Property" : "id"
@@ -48,23 +54,18 @@
       "Property" : "name"
     }
   }
-]
+/]
 
-[#assign AZURE_KEYVAULT_ACCESS_POLICY_OUTPUT_MAPPINGS =
+[@addOutputMapping 
+  provider=AZURE_PROVIDER
+  resourceType=AZURE_KEYVAULT_ACCESS_POLICY_RESOURCE_TYPE
+  mappings=
   {
     REFERENCE_ATTRIBUTE_TYPE : {
       "Property" : "id"
     }
   }
-]
-
-[#assign outputMappings +=
-  {
-    AZURE_KEYVAULT_RESOURCE_TYPE : AZURE_KEYVAULT_OUTPUT_MAPPINGS,
-    AZURE_KEYVAULT_SECRET_RESOURCE_TYPE : AZURE_KEYVAULT_SECRET_OUTPUT_MAPPINGS,
-    AZURE_KEYVAULT_ACCESS_POLICY_RESOURCE_TYPE : AZURE_KEYVAULT_ACCESS_POLICY_OUTPUT_MAPPINGS
-  }
-]
+/]
 
 [#function getKeyVaultSku family name]
   [#-- SKU for a KeyVault resides within the Properties object,

--- a/services/microsoft.managedidentity/resource.ftl
+++ b/services/microsoft.managedidentity/resource.ftl
@@ -13,7 +13,7 @@
 [#assign IDENTITY_OUTPUT_MAPPINGS =
     {
         REFERENCE_ATTRIBUTE_TYPE : {
-            "Attribute" : "id"
+            "Property" : "id"
         }
     }
 ]

--- a/services/microsoft.resources/resource.ftl
+++ b/services/microsoft.resources/resource.ftl
@@ -15,7 +15,9 @@
   resourceType=
   mappings=
     { 
-      REFERENCE_ATTRIBUTE_TYPE : { "Property" : "id" }
+      REFERENCE_ATTRIBUTE_TYPE : {
+        "Property" : "id"
+      }
     }
 /]
 

--- a/services/microsoft.storage/resource.ftl
+++ b/services/microsoft.storage/resource.ftl
@@ -36,7 +36,7 @@
 [#assign STORAGE_ACCOUNT_OUTPUT_MAPPINGS =
     {
         REFERENCE_ATTRIBUTE_TYPE : {
-            "UseRef" : true
+            "Property" : "id"
         },
         NAME_ATTRIBUTE_TYPE : {
             "Property" : "name"
@@ -53,7 +53,7 @@
 [#assign STORAGE_BLOB_OUTPUT_MAPPINGS =
     {
         REFERENCE_ATTRIBUTE_TYPE : {
-            "UseRef" : true
+            "Property" : "id"
         }
     }
 ]
@@ -61,7 +61,7 @@
 [#assign STORAGE_BLOB_CONTAINER_OUTPUT_MAPPINGS =
     {
         REFERENCE_ATTRIBUTE_TYPE : {
-            "UseRef" : true
+            "Property" : "id"
         },
         NAME_ATTRIBUTE_TYPE : {
             "Property" : "name"


### PR DESCRIPTION
Output mappings have changed since their first creation in the Azure provider. This refactor standardises them across all Services, and tidies up the ```@armResource``` for readability.

This PR also addresses an issue where the only outputs being created in a given template were the ones every template receives.