### PR TITLE
Refactor - OutputMappings into Resource Profile

### DIFF
--- a/deploymentframeworks/arm/output.ftl
+++ b/deploymentframeworks/arm/output.ftl
@@ -118,8 +118,7 @@
     plan={}
     zones=[]
     resources=[]
-    parentNames=[]
-    outputs={}]
+    parentNames=[]]
     
     [#--
         Note - "Identity" is a unique attribute and is not available to resources

--- a/deploymentframeworks/arm/output.ftl
+++ b/deploymentframeworks/arm/output.ftl
@@ -166,35 +166,32 @@
         ]
     /]
 
-    [#list outputMappings as provider,components]
-        [#list components as componentType,mappings]
-            [#list mappings as attributeType,attributes]
-                [#list attributes as attributeName,attributeValue]
+    [#list resourceProfile.outputMappings as attributeType,attributes]
+        [#list attributes as attributeName,attributeValue]
 
-                    [#if attributeValue == "id"]
-                        [#local outputName = id]
-                        [#local type = "string"]
-                        [#local value = getReference(id, name)]
-                    [#else]
-                        [#-- Properties that are "several": { "levels" : { "deep" : {}}} --]
-                        [#-- are referenced with a Property value of several.levels.deep --]
-                        [#local propertySections = attributeValue?split(".")]
-                        [#local outputName = formatAttributeId(id, propertySections)]
-                        [#local type = attributeValue?is_hash?then("object","string")]
-                        [#local typeFull = getAzureResourceProfile(getResourceType(id)).type]
-                        [#local value = getReference(id, name, typeFull, attributeType, "", "", attributeValue)]
-                    [/#if]
+            [#if attributeValue == "id"]
+                [#local outputName = id]
+                [#local type = "string"]
+                [#local value = getReference(id, name)]
+            [#else]
+                [#-- Properties that are "several": { "levels" : { "deep" : {}}} --]
+                [#-- are referenced with a Property value of several.levels.deep --]
+                [#local propertySections = attributeValue?split(".")]
+                [#local outputName = formatAttributeId(id, propertySections)]
+                [#local type = attributeValue?is_hash?then("object","string")]
+                [#local typeFull = getAzureResourceProfile(getResourceType(id)).type]
+                [#local value = getReference(id, name, typeFull, attributeType, "", "", attributeValue)]
+            [/#if]
 
-                    [@armOutput
-                        name=outputName
-                        type=type
-                        value=value
-                    /]
+            [@armOutput
+                name=outputName
+                type=type
+                value=value
+            /]
 
-                [/#list]
-            [/#list]
         [/#list]
     [/#list]
+
 [/#macro]
 
 [#macro arm_output_resource level="" include=""]

--- a/services/microsoft.compute/resource.ftl
+++ b/services/microsoft.compute/resource.ftl
@@ -6,22 +6,16 @@
   profile=
     {
       "apiVersion" : "2019-03-01",
-      "type" : "Microsoft.Compute/virtualMachineScaleSets"
+      "type" : "Microsoft.Compute/virtualMachineScaleSets",
+      "outputMappings" : {
+        REFERENCE_ATTRIBUTE_TYPE : {
+          "Property" : "id"
+        },
+        NAME_ATTRIBUTE_TYPE : {
+          "Property" : "name"
+        }
+      }
     }
-/]
-
-[@addOutputMapping 
-  provider=AZURE_PROVIDER
-  resourceType=AZURE_VIRTUALMACHINE_SCALESET_RESOURCE_TYPE
-  mappings=
-  {
-    REFERENCE_ATTRIBUTE_TYPE : {
-      "Property" : "id"
-    },
-    NAME_ATTRIBUTE_TYPE : {
-      "Property" : "name"
-    }
-  }
 /]
 
 [#function getVirtualMachineProfileLinuxConfigPublicKey

--- a/services/microsoft.compute/resource.ftl
+++ b/services/microsoft.compute/resource.ftl
@@ -118,7 +118,6 @@
   vmProfile
   identity={}
   zones=[]
-  outputs={}
   dependsOn={}]
 
   [@armResource
@@ -133,7 +132,6 @@
         "capacity" : skuCapacity
       }
     identity=identity
-    outputs=outputs
     dependsOn=dependsOn
     zones=zones
     properties=

--- a/services/microsoft.insights/resource.ftl
+++ b/services/microsoft.insights/resource.ftl
@@ -84,7 +84,6 @@
   targetId
   profiles
   notifications=[]
-  outputs={}
   dependsOn=[]]
 
   [@armResource
@@ -92,7 +91,6 @@
     name=name
     profile=AZURE_AUTOSCALE_SETTINGS_RESOURCE_TYPE
     location=location
-    outputs=outputs
     dependsOn=dependsOn
     properties=
       {

--- a/services/microsoft.insights/resource.ftl
+++ b/services/microsoft.insights/resource.ftl
@@ -6,19 +6,13 @@
   profile=
     {
       "apiVersion" : "2018-05-01-preview",
-      "type" : "Microsoft.Insights/autoscaleSettings"
+      "type" : "Microsoft.Insights/autoscaleSettings",
+      "outputMappings" : {
+        REFERENCE_ATTRIBUTE_TYPE : {
+          "Property" : "id"
+        }
+      }
     }
-/]
-
-[@addOutputMapping 
-  provider=AZURE_PROVIDER
-  resourceType=AZURE_AUTOSCALE_SETTINGS_RESOURCE_TYPE
-  mappings=
-  {
-    REFERENCE_ATTRIBUTE_TYPE : {
-      "Property" : "id"
-    }
-  }
 /]
 
 [#function getAutoScaleRule

--- a/services/microsoft.keyvault/resource.ftl
+++ b/services/microsoft.keyvault/resource.ftl
@@ -1,70 +1,52 @@
 [#ftl]
 
 [@addResourceProfile
-    service=AZURE_KEYVAULT_SERVICE
-    resource=AZURE_KEYVAULT_RESOURCE_TYPE
-    profile=
-        {
-            "apiVersion" : "2018-02-14",
-            "type" : "Microsoft.KeyVault/vaults",
-            "conditions" : [ "globally_unique" ]
+  service=AZURE_KEYVAULT_SERVICE
+  resource=AZURE_KEYVAULT_RESOURCE_TYPE
+  profile=
+    {
+      "apiVersion" : "2018-02-14",
+      "type" : "Microsoft.KeyVault/vaults",
+      "conditions" : [ "globally_unique" ],
+      "outputMappings":   {
+        REFERENCE_ATTRIBUTE_TYPE : {
+          "Property" : "id"
         }
+      }
+    }
 /]
 
 [@addResourceProfile
-    service=AZURE_KEYVAULT_SERVICE
-    resource=AZURE_KEYVAULT_SECRET_RESOURCE_TYPE
-    profile=
-        {
-            "apiVersion" : "2018-02-14",
-            "type" : "Microsoft.KeyVault/vaults/secrets"
+  service=AZURE_KEYVAULT_SERVICE
+  resource=AZURE_KEYVAULT_SECRET_RESOURCE_TYPE
+  profile=
+    {
+      "apiVersion" : "2018-02-14",
+      "type" : "Microsoft.KeyVault/vaults/secrets",
+      "outputMappings" : {
+        REFERENCE_ATTRIBUTE_TYPE : {
+          "Property" : "id"
+        },
+        NAME_ATTRIBUTE_TYPE : {
+          "Property" : "name"
         }
+      }
+    }
 /]
 
 [@addResourceProfile
     service=AZURE_KEYVAULT_SERVICE
     resource=AZURE_KEYVAULT_ACCESS_POLICY_RESOURCE_TYPE
     profile=
-        {
-            "apiVersion" : "2018-02-14",
-            "type" : "Microsoft.KeyVault/vaults/accessPolicies"
+      {
+        "apiVersion" : "2018-02-14",
+        "type" : "Microsoft.KeyVault/vaults/accessPolicies",
+        "outputMappings" : {
+          REFERENCE_ATTRIBUTE_TYPE : {
+            "Property" : "id"
+          }
         }
-/]
-
-[@addOutputMapping 
-  provider=AZURE_PROVIDER
-  resourceType=AZURE_KEYVAULT_RESOURCE_TYPE
-  mappings=
-  {
-    REFERENCE_ATTRIBUTE_TYPE : {
-      "Property" : "id"
-    }
-  }
-/]
-
-[@addOutputMapping 
-  provider=AZURE_PROVIDER
-  resourceType=AZURE_KEYVAULT_SECRET_RESOURCE_TYPE
-  mappings=
-  {
-    REFERENCE_ATTRIBUTE_TYPE : {
-      "Property" : "id"
-    },
-    NAME_ATTRIBUTE_TYPE : {
-      "Property" : "name"
-    }
-  }
-/]
-
-[@addOutputMapping 
-  provider=AZURE_PROVIDER
-  resourceType=AZURE_KEYVAULT_ACCESS_POLICY_RESOURCE_TYPE
-  mappings=
-  {
-    REFERENCE_ATTRIBUTE_TYPE : {
-      "Property" : "id"
-    }
-  }
+      }
 /]
 
 [#function getKeyVaultSku family name]

--- a/services/microsoft.keyvault/resource.ftl
+++ b/services/microsoft.keyvault/resource.ftl
@@ -169,7 +169,6 @@ convention ("object" suffix) is used to easily distinguish the two. --]
     properties=properties
     tags=tags
     resources=resources
-    outputs=AZURE_KEYVAULT_OUTPUT_MAPPINGS
     dependsOn=dependsOn
   /]
 
@@ -201,7 +200,6 @@ reference: https://tinyurl.com/y42ot42k --]
     name=name
     profile=AZURE_KEYVAULT_SECRET_RESOURCE_TYPE
     tags=tags
-    outputs=AZURE_KEYVAULT_SECRET_OUTPUT_MAPPINGS
     properties=properties
   /]
 [/#macro]

--- a/services/microsoft.managedidentity/resource.ftl
+++ b/services/microsoft.managedidentity/resource.ftl
@@ -30,6 +30,5 @@
         dependsOn=dependsOn
         properties={}
         tags=tags
-        outputs=IDENTITY_OUTPUT_MAPPINGS
     /]
 [#/macro]

--- a/services/microsoft.managedidentity/resource.ftl
+++ b/services/microsoft.managedidentity/resource.ftl
@@ -6,22 +6,13 @@
     profile=
         {
             "apiVersion" : "2018-11-30",
-            "type" : "Microsoft.ManagedIdentity/userAssignedIdentities"
+            "type" : "Microsoft.ManagedIdentity/userAssignedIdentities",
+            "outputMappings" : {
+                REFERENCE_ATTRIBUTE_TYPE : {
+                    "Property" : "id"
+                }
+            }
         }
-/]
-
-[#assign IDENTITY_OUTPUT_MAPPINGS =
-    {
-        REFERENCE_ATTRIBUTE_TYPE : {
-            "Property" : "id"
-        }
-    }
-]
-
-[@addOutputMapping 
-    provider=AZURE_PROVIDER
-    resourceType=AZURE_IAM_IDENTITY_RESOURCE_TYPE
-    mappings=IDENTITY_OUTPUT_MAPPINGS
 /]
 
 [#macro createUserAssignedIdentity

--- a/services/microsoft.network.applicationgateways/resource.ftl
+++ b/services/microsoft.network.applicationgateways/resource.ftl
@@ -6,17 +6,11 @@
   profile=
     {
       "apiVersion" : "2019-09-01",
-      "type" : "Microsoft.Network/applicationGateways"
-    }
-/]
-
-[@addOutputMapping
-  provider=AZURE_PROVIDER
-  resourceType=AZURE_APPLICATION_GATEWAY_RESOURCE_TYPE
-  mappings=
-    {
-      REFERENCE_ATTRIBUTE_TYPE : {
-        "Property" : "id"
+      "type" : "Microsoft.Network/applicationGateways",
+      "outputMappings" : {
+        REFERENCE_ATTRIBUTE_TYPE : {
+          "Property" : "id"
+        }
       }
     }
 /]

--- a/services/microsoft.network.applicationgateways/resource.ftl
+++ b/services/microsoft.network.applicationgateways/resource.ftl
@@ -441,7 +441,6 @@
   autoScaleMinCapacity=""
   autoScaleMaxCapacity=""
   identity={}
-  outputs={}
   dependsOn=[]]
 
   [#local sku = {} +
@@ -503,7 +502,6 @@
         attributeIfTrue("minCapacity", autoScaleMinCapacity) +
         attributeIfTrue("maxCapacity", autoScaleMaxCapacity)) +
       attributeIfContent("customErrorConfigurations", customErrorConfigurations)
-    outputs=outputs
     dependsOn=dependsOn
   /]
 

--- a/services/microsoft.network.frontdoor/resource.ftl
+++ b/services/microsoft.network.frontdoor/resource.ftl
@@ -161,7 +161,6 @@
   backendEnforceCertNameCheck=""
   backendSendRecvTimeoutSeconds=""
   tags={}
-  outputs={}
   dependsOn=[]]
 
   [@armResource
@@ -170,7 +169,6 @@
     profile=AZURE_FRONTDOOR_RESOURCE_TYPE
     dependsOn=dependsOn
     tags=tags
-    outputs=outputs
     properties={} +
       attributeIfContent("friendlyName", friendlyName) +
       attributeIfContent("routingRules", routingRules) +
@@ -265,7 +263,6 @@
   customRules=[]
   managedRules=[]
   tags={}
-  outputs={}
   dependsOn=[]]
 
   [@armResource

--- a/services/microsoft.network.frontdoor/resource.ftl
+++ b/services/microsoft.network.frontdoor/resource.ftl
@@ -6,7 +6,12 @@
   profile=
     {
       "apiVersion" : "2019-05-01",
-      "type" : "Microsoft.Network/frontDoors"
+      "type" : "Microsoft.Network/frontDoors",
+      "outputMappings" : {
+        REFERENCE_ATTRIBUTE_TYPE : {
+          "Property" : "id"
+        }
+      }
     }
 /]
 
@@ -16,38 +21,14 @@
   profile=
     {
       "apiVersion" : "2019-03-01",
-      "type" : "Microsoft.Network/FrontDoorWebApplicationFirewallPolicies"
+      "type" : "Microsoft.Network/FrontDoorWebApplicationFirewallPolicies",
+      "outputMappings" : {
+        REFERENCE_ATTRIBUTE_TYPE : {
+          "Property" : "id"
+        }
+      }
     }
 /]
-
-[#assign FRONTDOOR_OUTPUT_MAPPINGS = 
-  {
-    REFERENCE_ATTRIBUTE_TYPE : {
-      "Property" : "id"
-    }
-  }
-]
-
-[#assign FRONTDOOR_WAF_POLICY_OUTPUT_MAPPINGS = 
-  {
-    REFERENCE_ATTRIBUTE_TYPE : {
-      "Property" : "id"
-    }
-  }
-]
-
-[@addOutputMapping 
-  provider=AZURE_PROVIDER
-  resourceType=AZURE_FRONTDOOR_RESOURCE_TYPE
-  mappings=FRONTDOOR_OUTPUT_MAPPINGS
-/]
-
-[@addOutputMapping 
-  provider=AZURE_PROVIDER
-  resourceType=AZURE_FRONTDOOR_WAF_POLICY_RESOURCE_TYPE
-  mappings=FRONTDOOR_WAF_POLICY_OUTPUT_MAPPINGS
-/]
-
 
 [#function getFrontDoorRoutingRule
   id=""

--- a/services/microsoft.network/resource.ftl
+++ b/services/microsoft.network/resource.ftl
@@ -3,91 +3,86 @@
 [#assign networkResourceProfiles = {
   AZURE_APPLICATION_SECURITY_GROUP_RESOURCE_TYPE : {
     "apiVersion" : "2019-04-01",
-    "type" : "Microsoft.Network/applicationSecurityGroups"
+    "type" : "Microsoft.Network/applicationSecurityGroups",
+    "outputMappings" : {}
   },
   AZURE_ROUTE_TABLE_RESOURCE_TYPE : {
     "apiVersion" : "2019-02-01",
-    "type" : "Microsoft.Network/routeTables"
+    "type" : "Microsoft.Network/routeTables",
+    "outputMappings" : {}
   },
   AZURE_ROUTE_TABLE_ROUTE_RESOURCE_TYPE : {
     "apiVersion" : "2019-02-01",
-    "type" : "Microsoft.Network/routeTables/routes"
+    "type" : "Microsoft.Network/routeTables/routes",
+    "outputMappings" : {}
   },
   AZURE_SERVICE_ENDPOINT_POLICY_RESOURCE_TYPE : {
     "apiVersion" : "2019-02-01",
-    "type" : "Microsoft.Network/serviceEndpointPolicies"
+    "type" : "Microsoft.Network/serviceEndpointPolicies",
+    "outputMappings" : {}
   },
   AZURE_SERVICE_ENDPOINT_POLICY_DEFINITION_RESOURCE_TYPE : {
     "apiVersion" : "2019-02-01",
-    "type" : "Microsoft.Network/serviceEndpointPolicies/serviceEndpointPolicyDefinitions"
+    "type" : "Microsoft.Network/serviceEndpointPolicies/serviceEndpointPolicyDefinitions",
+    "outputMappings" : {}
   },
   AZURE_SUBNET_RESOURCE_TYPE : {
     "apiVersion" : "2019-02-01",
-    "type" : "Microsoft.Network/virtualNetworks/subnets"
+    "type" : "Microsoft.Network/virtualNetworks/subnets",
+    "outputMappings" : {
+      REFERENCE_ATTRIBUTE_TYPE : {
+        "Property" : "id"
+      }
+    }
   },
   AZURE_VIRTUAL_NETWORK_RESOURCE_TYPE : {
     "apiVersion" : "2019-02-01",
-    "type" : "Microsoft.Network/virtualNetworks"
+    "type" : "Microsoft.Network/virtualNetworks",
+    "outputMappings" : {
+      REFERENCE_ATTRIBUTE_TYPE : {
+        "Property" : "id"
+      }
+    }
   },
   AZURE_VIRTUAL_NETWORK_PEERING_RESOURCE_TYPE : {
     "apiVersion" : "2019-02-01",
-    "type" : "Microsoft.Network/virtualNetworks/virtualNetworkPeerings"
+    "type" : "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
+    "outputMappings" : {}
   },
   AZURE_VIRTUAL_NETWORK_SECURITY_GROUP_RESOURCE_TYPE : {
     "apiVersion" : "2019-02-01",
-    "type" : "Microsoft.Network/networkSecurityGroups"
+    "type" : "Microsoft.Network/networkSecurityGroups",
+    "outputMappings" : {}
   },
   AZURE_VIRTUAL_NETWORK_SECURITY_GROUP_SECURITY_RULE_RESOURCE_TYPE : {
     "apiVersion" : "2019-04-01",
-    "type" : "Microsoft.Network/networkSecurityGroups/securityRules"
+    "type" : "Microsoft.Network/networkSecurityGroups/securityRules",
+    "outputMappings" : {}
   },
   AZURE_NETWORK_WATCHER_RESOURCE_TYPE : {
     "apiVersion" : "2019-04-01",
-    "type" : "Microsoft.Network/networkWatchers"
+    "type" : "Microsoft.Network/networkWatchers",
+    "outputMappings" : {}
   },
   AZURE_PRIVATE_DNS_ZONE_RESOURCE_TYPE : {
     "apiVersion" : "2018-09-01",
-    "type" : "Microsoft.Network/privateDnsZones"
+    "type" : "Microsoft.Network/privateDnsZones",
+    "outputMappings" : {}
   },
   AZURE_PRIVATE_DNS_ZONE_VNET_LINK_RESOURCE_TYPE : {
     "apiVersion" : "2018-09-01",
-    "type" : "Microsoft.Network/privateDnsZones/virtualNetworkLinks"
+    "type" : "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
+    "outputMappings" : {}
   }
 }]
 
-[#list networkResourceProfiles as resource,attributes]
+[#list networkResourceProfiles as resourceType,resourceProfile]
   [@addResourceProfile
     service=AZURE_NETWORK_SERVICE
-    resource=resource
-    profile=
-      {
-        "apiVersion" : attributes.apiVersion,
-        "type" : attributes.type
-      }
+    resource=resourceType
+    profile=resourceProfile
   /]
 [/#list]
-
-[@addOutputMapping 
-  provider=AZURE_PROVIDER
-  resourceType=AZURE_VIRTUAL_NETWORK_RESOURCE_TYPE
-  mappings=
-    {
-      REFERENCE_ATTRIBUTE_TYPE : {
-        "Property" : "id"
-      }
-    }
-/]
-
-[@addOutputMapping 
-  provider=AZURE_PROVIDER
-  resourceType=AZURE_SUBNET_RESOURCE_TYPE
-  mappings=
-    {
-      REFERENCE_ATTRIBUTE_TYPE : {
-        "Property" : "id"
-      }
-    }
-/]
 
 [#macro createApplicationSecurityGroup id name location tags={}]
   [@armResource

--- a/services/microsoft.network/resource.ftl
+++ b/services/microsoft.network/resource.ftl
@@ -110,7 +110,6 @@
   description=""
   priority=4096
   tags={}
-  outputs={}
   dependsOn=[]]
 
   [#local destinationPortProfile = ports[destinationPortProfileName]]
@@ -149,7 +148,6 @@
       attributeIfContent("description", description) +
       attributeIfContent("priority", priority)
     tags=tags
-    outputs=outputs
   /]
   
 [/#macro]
@@ -161,7 +159,6 @@
   addressPrefix="" 
   nextHopIpAddress=""
   dependsOn=[]
-  outputs={}
   tags={}]
 
   [@armResource
@@ -172,7 +169,6 @@
       attributeIfContent("addressPrefix", addressPrefix) +
       attributeIfContent("nextHopIpAddress", nextHopIpAddress)
     dependsOn=dependsOn
-    outputs=outputs
     tags=tags
   /]
 
@@ -185,8 +181,7 @@
   disableBgpRoutePropagation=false
   location=""
   tags={}
-  dependsOn=[]
-  outputs={}]
+  dependsOn=[]]
 
   [@armResource
     id=id
@@ -198,7 +193,6 @@
       attributeIfContent("routes", routes) +
       attributeIfTrue("disableBgpRoutePropagation", disableBgpRoutePropagation, disableBgpRoutePropagation)
     dependsOn=dependsOn
-    outputs=outputs
   /]
 
 [/#macro]
@@ -209,8 +203,7 @@
   location=""
   tags={}
   resources=[]
-  dependsOn=[]
-  outputs={}]
+  dependsOn=[]]
 
   [@armResource
     id=id
@@ -220,7 +213,6 @@
     tags=tags
     resources=resources
     dependsOn=dependsOn
-    outputs=outputs
   /]
 [/#macro]
 
@@ -230,8 +222,7 @@
   description=""
   service=""
   serviceResources=[]
-  dependsOn=[]
-  outputs={}]
+  dependsOn=[]]
 
   [@armResource
     id=id
@@ -242,7 +233,6 @@
       attributeIfContent("service", service) +
       attributeIfContent("serviceResources", serviceResources)
     dependsOn=dependsOn
-    outputs=outputs
   /]
 [/#macro]
 
@@ -356,7 +346,6 @@
   remoteVirtualNetworkId=""
   remoteAddressSpacePrefixes=[]
   peeringState=""
-  outputs={}
   dependsOn=[]]
 
   [@armResource
@@ -371,7 +360,6 @@
       attributeIfContent("remoteVirtualNetwork", { "id" : remoteVirtualNetworkId } ) +
       attributeIfContent("remoteAddressSpace", { "addressPrefixes" : remoteAddressSpacePrefixes } ) +
       attributeIfContent("peeringState", peeringState)
-    outputs=outputs
     dependsOn=dependsOn
   /]
 [/#macro]
@@ -382,7 +370,6 @@
   dnsServers=[]
   addressSpacePrefixes=[]
   location=regionId
-  outputs={}
   dependsOn=[]]
 
   [@armResource
@@ -390,7 +377,6 @@
     name=name
     profile=AZURE_VIRTUAL_NETWORK_RESOURCE_TYPE
     location=location
-    outputs=outputs
     dependsOn=dependsOn
     properties={} +
       attributeIfContent("addressSpace", {} + 
@@ -421,7 +407,6 @@
   formatType=""
   formatVersion=""
   location=""
-  outputs={}
   dependsOn=[]]
 
   [#local networkWatcherFlowAnalyticsConfiguration = { "enabled" : true } +
@@ -450,7 +435,6 @@
       attributeIfContent("retentionPolicy", retentionPolicy) +
       attributeIfContent("format", format)
     location=location
-    outputs=outputs
     dependsOn=dependsOn
   /]
 [/#macro]

--- a/services/microsoft.resources/resource.ftl
+++ b/services/microsoft.resources/resource.ftl
@@ -81,7 +81,6 @@
   zones=[]
   resources=[]
   parentNames=[]
-  outputs={}
   deploymentResourceId="defaultDeploymentResource"
   deploymentResourceName="default"
   deploymentResourceMode="Incremental"

--- a/services/microsoft.resources/resource.ftl
+++ b/services/microsoft.resources/resource.ftl
@@ -6,17 +6,11 @@
   profile=
     {
       "apiVersion" : "2019-10-01",
-      "type" : "Microsoft.Resources/deployments"
-    }
-/]
-
-[@addOutputMappings
-  provider=AZURE_PROVIDER
-  resourceType=
-  mappings=
-    { 
-      REFERENCE_ATTRIBUTE_TYPE : {
-        "Property" : "id"
+      "type" : "Microsoft.Resources/deployments",
+      "outputMappings" : { 
+        REFERENCE_ATTRIBUTE_TYPE : {
+          "Property" : "id"
+        }
       }
     }
 /]

--- a/services/microsoft.storage/resource.ftl
+++ b/services/microsoft.storage/resource.ftl
@@ -165,7 +165,6 @@
         tags=tags
         identity={ "type" : "SystemAssigned" }
         sku=sku
-        outputs=STORAGE_ACCOUNT_OUTPUT_MAPPINGS
         properties=
             {
                 "supportsHttpsTrafficOnly" : supportHttpsTrafficOnly
@@ -214,7 +213,6 @@
         profile=AZURE_BLOBSERVICE_RESOURCE_TYPE
         dependsOn=dependsOn
         resources=resources
-        outputs=STORAGE_BLOB_OUTPUT_MAPPINGS
         properties=
             {} + 
             attributeIfContent("cors", attributeIfContent("CORSRules", CORSRules)) +
@@ -240,7 +238,6 @@
         profile=AZURE_BLOBSERVICE_CONTAINER_RESOURCE_TYPE
         resources=resources
         dependsOn=dependsOn
-        outputs=STORAGE_BLOB_CONTAINER_OUTPUT_MAPPINGS
         properties=
             {} +
             attributeIfContent("publicAccess", publicAccess) +

--- a/services/microsoft.storage/resource.ftl
+++ b/services/microsoft.storage/resource.ftl
@@ -7,7 +7,21 @@
         {
             "apiVersion" : "2019-04-01",
             "type" : "Microsoft.Storage/storageAccounts",
-            "conditions" : [ "alphanumeric_only", "name_to_lower", "globally_unique" ]
+            "conditions" : [ "alphanumeric_only", "name_to_lower", "globally_unique" ],
+            "outputMappings" : {
+                REFERENCE_ATTRIBUTE_TYPE : {
+                    "Property" : "id"
+                },
+                NAME_ATTRIBUTE_TYPE : {
+                    "Property" : "name"
+                },
+                URL_ATTRIBUTE_TYPE : {
+                    "Property" : "properties.primaryEndpoints.blob"
+                },
+                REGION_ATTRIBUTE_TYPE : {
+                    "Property" : "properties.primaryLocation"
+                }
+            }
         }
 /]
 
@@ -18,7 +32,12 @@
         {
             "apiVersion" : "2019-04-01",
             "type" : "Microsoft.Storage/storageAccounts/blobServices",
-            "conditions" : [ "name_to_lower", "parent_to_lower" ]
+            "conditions" : [ "name_to_lower", "parent_to_lower" ],
+            "outputMappings" : {
+                REFERENCE_ATTRIBUTE_TYPE : {
+                    "Property" : "id"
+                }
+            }
         }
 /]
 
@@ -29,60 +48,17 @@
         {
             "apiVersion" : "2019-04-01",
             "type" : "Microsoft.Storage/storageAccounts/blobServices/containers",
-            "conditions" : [ "name_to_lower", "parent_to_lower" ]
+            "conditions" : [ "name_to_lower", "parent_to_lower" ],
+            "outputMappings" : {
+                REFERENCE_ATTRIBUTE_TYPE : {
+                    "Property" : "id"
+                },
+                NAME_ATTRIBUTE_TYPE : {
+                    "Property" : "name"
+                }
+            }
         }
 /]
-
-[#assign STORAGE_ACCOUNT_OUTPUT_MAPPINGS =
-    {
-        REFERENCE_ATTRIBUTE_TYPE : {
-            "Property" : "id"
-        },
-        NAME_ATTRIBUTE_TYPE : {
-            "Property" : "name"
-        },
-        URL_ATTRIBUTE_TYPE : {
-            "Property" : "properties.primaryEndpoints.blob"
-        },
-        REGION_ATTRIBUTE_TYPE : {
-            "Property" : "properties.primaryLocation"
-        }
-    }
-]
-
-[#assign STORAGE_BLOB_OUTPUT_MAPPINGS =
-    {
-        REFERENCE_ATTRIBUTE_TYPE : {
-            "Property" : "id"
-        }
-    }
-]
-
-[#assign STORAGE_BLOB_CONTAINER_OUTPUT_MAPPINGS =
-    {
-        REFERENCE_ATTRIBUTE_TYPE : {
-            "Property" : "id"
-        },
-        NAME_ATTRIBUTE_TYPE : {
-            "Property" : "name"
-        }
-    }
-]
-[#assign storageMappings = 
-    {
-        AZURE_BLOBSERVICE_CONTAINER_RESOURCE_TYPE : STORAGE_BLOB_CONTAINER_OUTPUT_MAPPINGS,
-        AZURE_BLOBSERVICE_RESOURCE_TYPE : STORAGE_BLOB_OUTPUT_MAPPINGS,
-        AZURE_STORAGEACCOUNT_RESOURCE_TYPE : STORAGE_ACCOUNT_OUTPUT_MAPPINGS
-    }
-]
-
-[#list storageMappings as type, mappings]
-    [@addOutputMapping 
-        provider=AZURE_PROVIDER
-        resourceType=type
-        mappings=mappings
-    /]
-[/#list]
 
 [#function getStorageSku tier replication reasonCodes...]
     [#return

--- a/services/microsoft.web/resource.ftl
+++ b/services/microsoft.web/resource.ftl
@@ -6,7 +6,12 @@
     profile=
         {
             "apiVersion" : "2019-08-01",
-            "type" : "Microsoft.Web/serverfarms"
+            "type" : "Microsoft.Web/serverfarms",
+            "outputMappings" : {
+                REFERENCE_ATTRIBUTE_TYPE : {
+                    "Property" : "id"
+                }
+            }
         }
 /]
 
@@ -16,28 +21,11 @@
     profile=
         {
             "apiVersion": "2019-08-01",
-            "type" : "Microsoft.Web/sites"
-        }
-/]
-
-[@addOutputMapping
-    provider=AZURE_PROVIDER
-    resourceType=AZURE_APP_SERVICE_PLAN_RESOURCE_TYPE
-    mappings=
-        {
-            REFERENCE_ATTRIBUTE_TYPE : {
-                "Property" : "id"
-            }
-        }
-/]
-
-[@addOutputMapping
-    provider=AZURE_PROVIDER
-    resourceType=AZURE_WEB_APP_RESOURCE_TYPE
-    mappings=
-        {
-            REFERENCE_ATTRIBUTE_TYPE : {
-                "Property" : "id"
+            "type" : "Microsoft.Web/sites",
+            "outputMappings" : {
+                REFERENCE_ATTRIBUTE_TYPE : {
+                    "Property" : "id"
+                }
             }
         }
 /]

--- a/services/resource.ftl
+++ b/services/resource.ftl
@@ -25,6 +25,11 @@
                 "Names" : "conditions",
                 "Type" : ARRAY_OF_STRING_TYPE,
                 "Default" : []
+            },
+            {
+                "Names" : "outputMappings",
+                "type" : OBJECT_TYPE,
+                "Mandatory" : true
             }
         ]
     }
@@ -35,6 +40,15 @@
         service=service
         resource=resource
         profile=profile
+    /]
+
+    [#-- Update outputMappings from profile
+        Though outputMappings are now accessible from the profile, its important to use
+        "outputMapping" variable to support cross-provider implementation.          --]
+    [@addOutputMapping 
+        provider=AZURE_PROVIDER
+        resourceType=resource
+        mappings=profile.outputMappings
     /]
 [/#macro]
 


### PR DESCRIPTION
When implementing a new resource in the Azure Provider, two related macros are always required - ```addResourceProfile``` (azure-specific macro) and ```addOutputMappings``` (codeontap macro). The output Mappings define an individual resources outputs when instantiated, and lends itself quite well to being a part of the profile. This PR incorporates the outputMappings as a mandatory attribute of the Resource Profile, reducing the number of macro calls and duplication.

In order to continue to support cross-provider outputs (through ```getOutputMappings```, macro ```addResourceProfile``` will still call ```addOutputMappings``` behind the scenes, but when adding a resource to a template through ```armResource``` we will make reference to the resource profile because its always going to be Azure-specific output mappings.