### PR TITLE
Refactor - Remove baseState from State macros

### DIFF
--- a/components/baseline/state.ftl
+++ b/components/baseline/state.ftl
@@ -1,6 +1,6 @@
 [#ftl]
 
-[#macro azure_baseline_arm_state occurrence parent={} baseState={}]
+[#macro azure_baseline_arm_state occurrence parent={}]
   [#local core = occurrence.Core]
   [#local solution = occurrence.Configuration.Solution]
   
@@ -51,7 +51,7 @@
   ]
 [/#macro]
 
-[#macro azure_baselinedata_arm_state occurrence parent={} baseState={}]
+[#macro azure_baselinedata_arm_state occurrence parent={}]
   [#local core = occurrence.Core]
   [#local solution = occurrence.Configuration.Solution]
 
@@ -75,7 +75,7 @@
   ]
 [/#macro]
 
-[#macro azure_baselinekey_arm_state occurrence parent={} baseState={}]
+[#macro azure_baselinekey_arm_state occurrence parent={}]
   [#local core = occurrence.Core]
   [#local solution = occurrence.Configuration.Solution]
   

--- a/components/gateway/state.ftl
+++ b/components/gateway/state.ftl
@@ -1,6 +1,6 @@
 [#ftl]
 
-[#macro azure_gateway_arm_state occurrence parent={} baseState={}]
+[#macro azure_gateway_arm_state occurrence parent={}]
 
   [#local core = occurrence.Core]
   [#local solution = occurrence.Configuration.Solution]
@@ -43,7 +43,7 @@
 
 [/#macro]
 
-[#macro azure_gatewaydestination_arm_state occurrence parent={} baseState={}]
+[#macro azure_gatewaydestination_arm_state occurrence parent={}]
   [#local core = occurrence.Core]
   [#local solution = occurrence.Configuration.Solution]
 

--- a/components/network/state.ftl
+++ b/components/network/state.ftl
@@ -1,6 +1,6 @@
 [#ftl]
 
-[#macro azure_network_arm_state occurrence parent={} baseState={}]
+[#macro azure_network_arm_state occurrence parent={}]
   
   [#local core = occurrence.Core]
   [#local solution = occurrence.Configuration.Solution]
@@ -109,7 +109,7 @@
   ]
 [/#macro]
 
-[#macro azure_networkroute_arm_state occurrence parent={} baseState={}]
+[#macro azure_networkroute_arm_state occurrence parent={}]
   [#local core = occurrence.Core]
   [#local solution = occurrence.Configuration.Solution]
 
@@ -152,7 +152,7 @@ resource. It remains "networkacl" in name to ensure there is no clash
 with any future networkSecurityGroup components. When referring to
 the Resource alone, it will remain NetworkSecurityGroup for clarity
 as Azure does not have NetworkACLs.--]
-[#macro azure_networkacl_arm_state occurrence parent={} baseState={}]
+[#macro azure_networkacl_arm_state occurrence parent={}]
 
   [#local core = occurrence.Core]
   [#local solution = occurrence.Configuration.Solution]

--- a/components/s3/state.ftl
+++ b/components/s3/state.ftl
@@ -1,6 +1,6 @@
 [#ftl]
 
-[#macro azure_s3_arm_state occurrence parent={} baseState={}]
+[#macro azure_s3_arm_state occurrence parent={}]
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]
 

--- a/components/spa/state.ftl
+++ b/components/spa/state.ftl
@@ -1,6 +1,6 @@
 [#ftl]
 
-[#macro azure_spa_arm_state occurrence parent={} baseState={}]
+[#macro azure_spa_arm_state occurrence parent={}]
 
   [#local core = occurrence.Core]
   [#local solution = occurrence.Configuration.Solution]


### PR DESCRIPTION
Contributes to codeontap/gen3#1215

As per the associated gen3 PR, this attribute is no longer supported and has been removed.

@ml019 please merge along with your PR.