### PR TITLE
Default StorageAccount Kind Update

### DIFF
--- a/inputsources/shared/masterdata.ftl
+++ b/inputsources/shared/masterdata.ftl
@@ -361,7 +361,7 @@
           "storageAccount": {
             "Tier": "Standard",
             "Replication": "LRS",
-            "Type": "BlobStorage",
+            "Type": "StorageV2",
             "AccessTier": "Cool",
             "HnsEnabled": false
           }


### PR DESCRIPTION
Azure has a number of different StorageAccount [types that can be created](https://docs.microsoft.com/en-gb/azure/storage/common/storage-account-overview). Typically they recommend the generic types of v1 (legacy) or v2, however if you know exactly what you are looking for then you can get some performance enhancements for specific use-cases by specifying specific types like BlobStorage or FileStorage. When you do this the other types are not enabled on the storage account.

This PR makes the "default" storageProfile for Azure use the StorageV2 type, which will allow storage of all kinds by default. This will be useful for the Baseline component, to ensure the maximum coverage of storage scenarios.