### PR TITLE
Component - SQS

### DIFF
--- a/components/baseline/state.ftl
+++ b/components/baseline/state.ftl
@@ -68,7 +68,8 @@
       },
       "Attributes": {
         "ACCOUNT_NAME" : storageAccountName,
-        "PRIMARY_ENDPOINT" : formatDomainName(storageAccountName, "blob.core.windows.net")
+        "PRIMARY_ENDPOINT" : formatDomainName(storageAccountName, "blob.core.windows.net"),
+        "QUEUE_ENDPOINT": formatDomainName(storageAccountName, "queue.core.windows.net")
       },
       "Roles": {
         "Inbound": {},

--- a/components/sqs/id.ftl
+++ b/components/sqs/id.ftl
@@ -1,0 +1,11 @@
+[#ftl]
+[@addResourceGroupInformation
+    type=SQS_COMPONENT_TYPE
+    attributes=[]
+    provider=AZURE_PROVIDER
+    resourceGroup=DEFAULT_RESOURCE_GROUP
+    services=
+        [
+            AZURE_STORAGE_SERVICE
+        ]
+/]

--- a/components/sqs/setup.ftl
+++ b/components/sqs/setup.ftl
@@ -1,0 +1,49 @@
+[#ftl]
+
+[#macro azure_sqs_arm_genplan_solution occurrence]
+    [#-- Queue creation is not yet available within ARM                --]
+    [#-- No template is therefore required - all work done through CLI --]
+    [#-- TODO(rossmurr4y): Keep an eye on ARM support:                 --]
+    [#-- https://tinyurl.com/r2zpv8v                                   --]
+    [@addDefaultGenerationPlan subsets=["prologue"] /]
+[/#macro]
+
+[#macro azure_sqs_arm_setup_solution occurrence]
+    
+    [@debug message="Entering SQS Setup" context=occurrence enabled=false /]
+
+    [#local core = occurrence.Core]
+    [#local solution = occurrence.Configuration.Solution]
+    [#local resources = occurrence.State.Resources]
+
+    [#if deploymentSubsetRequired("prologue", true)]
+
+        [#local queue = resources["queue"]]
+
+        [@addToDefaultBashScriptOutput
+            content=
+            [
+                "case $\{STACK_OPERATION} in",
+                "  create|update)"
+                "    # Create Storage Account Queue",
+                "    info \"Creating Queue Storage ... \"",
+                "    az_interact_storage_queue" +
+                    " \"" + queue.StorageAccount + "\"" +
+                    " \"" + queue.Name + "\"" +
+                    " \"" + "create" + "\" || return $?"
+                    ";;",
+                "  delete)"
+                "    # Deleting Storage Account Queue",
+                "    info \"Deleting Queue Storage ... \"",
+                "    az_interact_storage_queue" +
+                    " \"" + queue.StorageAccount + "\"" +
+                    " \"" + queue.Name + "\"" +
+                    " \"" + "delete" + "\" || return $?"
+                    ";;",
+                "esac"
+            ]
+        /]
+
+    [/#if]
+
+[/#macro]

--- a/components/sqs/state.ftl
+++ b/components/sqs/state.ftl
@@ -1,0 +1,36 @@
+[#ftl]
+
+[#macro azure_sqs_arm_state occurrence parent={} baseState={}]
+
+    [#local core = occurrence.Core]
+    [#local solution = occurrence.Configuration.Solution]
+
+    [#-- Baseline component lookup --]
+    [#local baselineLinks = getBaselineLinks(occurrence, [ "OpsData" ], false, false)]
+    [#local baselineAttributes = baselineLinks["OpsData"].State.Attributes]
+
+    [#local storageAccount = baselineAttributes["ACCOUNT_NAME"]]
+    [#local queueUrl = baselineAttributes["QUEUE_ENDPOINT"]]
+    [#local queueId = formatResourceId(AZURE_STORAGEACCOUNT_RESOURCE_TYPE, core.Id)]
+    [#local queueName = formatAzureResourceName(core.ShortTypedName, getResourceType(queueId))]
+    [@debug message="baselineLinks" context=baselineLinks enabled=true /]
+    [#assign componentState =
+        {
+            "Resources" : {
+                "queue" : {
+                    "Id" : queueId,
+                    "Name" : queueName,
+                    "StorageAccount": storageAccount
+                }
+            },
+            "Attributes" : {
+                "URL": formatRelativePath(queueUrl, queueName)
+            },
+            "Roles" : {
+                "Inbound" : {},
+                "Outbound" : {}
+            }
+        }
+    ]
+
+[/#macro]

--- a/utility.sh
+++ b/utility.sh
@@ -42,6 +42,15 @@ function az_copy_from_blob(){
     --no-progress > /dev/null || return $?
 }
 
+function az_interact_storage_queue(){
+  local storageAccountName="$1"; shift
+  local queueName="$1"; shift
+  local action="$1"; shift
+
+  connectionString=$(az storage account show-connection-string --name "${storageAccountName}" | jq '.["connectionString"]') || return $?
+  az storage queue ${action} --name "${queueName}" --connection-string "${connectionString}"  || return $?
+}
+
 # sync is in public preview as of Jan 2020.
 function az_sync_with_blob(){
   local storageAccountName="$1"; shift


### PR DESCRIPTION
Closes #64 

Implements the MVP for the SQS Component.

Note that there is currently no Azure Resource for deploying a Queue resource to the Azure Storage Account. This template generates a prologue script that will use the CLI to accomplish the same goal, with the aim to replace this once MSFT implement a queue resource.