### PR TITLE
Refactor - SQS BaseState

### DIFF
--- a/components/sqs/state.ftl
+++ b/components/sqs/state.ftl
@@ -1,6 +1,6 @@
 [#ftl]
 
-[#macro azure_sqs_arm_state occurrence parent={} baseState={}]
+[#macro azure_sqs_arm_state occurrence parent={}]
 
     [#local core = occurrence.Core]
     [#local solution = occurrence.Configuration.Solution]


### PR DESCRIPTION
SQS component was being developed whilst the baseState changes of codeontap/gen3#1215 was being reviewed. Had to exist for development but now should be removed.