### PR TITLE
Component - S3

### DIFF
--- a/components/baseline/setup.ftl
+++ b/components/baseline/setup.ftl
@@ -89,7 +89,7 @@
       For now we just want blanket "deny-all" networkAcls.
     --]
     [#-- networkAcls object is used for both Storage Account and KeyVault --]
-    [#local storageNetworkAclsConfiguration = getNetworkAcls("Deny", [], [], "AzureServices")]
+    [#local storageNetworkAclsConfiguration = getNetworkAcls("Allow", [], [], "AzureServices")]
 
     [@createStorageAccount
       id=accountId

--- a/components/s3/setup.ftl
+++ b/components/s3/setup.ftl
@@ -18,11 +18,6 @@
     [#local blobName = resources["blobService"].Name]
     [#local containerName = resources["container"].Name]
 
-    [#-- Process Resource Naming Conditions --]
-    [#local accountName = formatAzureResourceName(accountName, getResourceType(accountId))]
-    [#local blobName = formatAzureResourceName(blobName, getResourceType(blobId), accountName)]
-    [#local containerName = formatAzureResourceName(containerName, getResourceType(containerId), blobName)]
-
     [#local storageProfile = getStorage(occurrence, "storageAccount")]
 
     [#-- Baseline component lookup

--- a/components/s3/state.ftl
+++ b/components/s3/state.ftl
@@ -16,26 +16,32 @@
         [/#if]
     [/#list]
 
-    [#--
-        Note: it is a requirement that the blobService name is "default" in all cases.
-        https://tinyurl.com/yxozph9o
-    --]
+    [#-- Process Resource Naming Conditions                                             --]
+    [#-- Note: it is a requirement that the blobService name is "default" in all cases. --]
+    [#-- https://tinyurl.com/yxozph9o                                                   --]
+    [#local accountName = formatName(AZURE_STORAGEACCOUNT_RESOURCE_TYPE, core.ShortName)]
+    [#local blobName = "default"]
+    [#local containerName = formatName(AZURE_BLOBSERVICE_CONTAINER_RESOURCE_TYPE, core.ShortName)]
+    [#local accountName = formatAzureResourceName(accountName, AZURE_STORAGEACCOUNT_RESOURCE_TYPE)]
+    [#local blobName = formatAzureResourceName(blobName, AZURE_BLOBSERVICE_RESOURCE_TYPE, accountName)]
+    [#local containerName = formatAzureResourceName(containerName, AZURE_BLOBSERVICE_CONTAINER_RESOURCE_TYPE, blobName)]
+
     [#assign componentState=
         {
             "Resources" : {
                 "storageAccount" : {
                     "Id" : storageAccountId,
-                    "Name" : formatName(AZURE_STORAGEACCOUNT_RESOURCE_TYPE, core.ShortName),
+                    "Name" : accountName,
                     "Type" : AZURE_STORAGEACCOUNT_RESOURCE_TYPE
                 },
                 "blobService" : {
                     "Id" : blobId,
-                    "Name" : "default",
+                    "Name" : blobName,
                     "Type" : AZURE_BLOBSERVICE_RESOURCE_TYPE
                 },
                 "container" : {
                     "Id" : containerId,
-                    "Name" : formatName(AZURE_BLOBSERVICE_CONTAINER_RESOURCE_TYPE, core.ShortName),
+                    "Name" : containerName,
                     "Type" : AZURE_BLOBSERVICE_CONTAINER_RESOURCE_TYPE
                 }
             },

--- a/services/microsoft.storage/resource.ftl
+++ b/services/microsoft.storage/resource.ftl
@@ -7,7 +7,8 @@
         {
             "apiVersion" : "2019-04-01",
             "type" : "Microsoft.Storage/storageAccounts",
-            "conditions" : [ "alphanumeric_only", "name_to_lower", "globally_unique" ],
+            "conditions" : [ "alphanumeric_only", "name_to_lower", "globally_unique", "max_length" ],
+            "max_name_length" : 24,
             "outputMappings" : {
                 REFERENCE_ATTRIBUTE_TYPE : {
                     "Property" : "id"

--- a/services/resource.ftl
+++ b/services/resource.ftl
@@ -27,6 +27,11 @@
                 "Default" : []
             },
             {
+                "Names" : "max_name_length",
+                "Type" : NUMBER_TYPE,
+                "Mandatory" : false
+            },
+            {
                 "Names" : "outputMappings",
                 "type" : OBJECT_TYPE,
                 "Mandatory" : true
@@ -210,7 +215,8 @@ id, name, type, location, managedBy, tags, properties.provisioningState --]
 --]
 [#function formatAzureResourceName name profile primaryParent=""]
     
-    [#local conditions = getAzureResourceProfile(profile).conditions]
+    [#local resourceProfile = getAzureResourceProfile(profile)]
+    [#local conditions = resourceProfile.conditions]
     [#local conditions += ["segment_out_names"]]
     [#list conditions as condition]
         [#switch condition]
@@ -220,6 +226,9 @@ id, name, type, location, managedBy, tags, properties.provisioningState --]
             [#case "globally_unique"]
                 [#local segmentSeed = getStackOutput(AZURE_PROVIDER, formatSegmentSeedId())]
                 [#local name = name?ensure_ends_with(segmentSeed)]
+                [#break]
+            [#case "max_length"]
+                [#local name = name[0..(resourceProfile.max_name_length - 1)]]
                 [#break]
             [#case "name_to_lower"]
                 [#local name = name?lower_case]


### PR DESCRIPTION
Contributes to and Closes #65 

More a refactor as this component was the first created, though with less explicit requirements.

This refactor revisits the naming of storage account, container and blob store resources to ensure that their naming conditions are all met. It also introduces a new resourceProfile attribute - ```max_name_length```. This attribute is read during the processing of the naming condition "max_length" (also new) and abbreviates the name accordingly.

Finally the networkACL for this component defaults to Allow, to allow for administration of the storageAccount. As the component evolves this will become further locked down, however for now it will rely upon authentication.