### PR TITLE
ELB into Separate Network Security Group

### DIFF
--- a/inputsources/shared/masterdata.ftl
+++ b/inputsources/shared/masterdata.ftl
@@ -1058,6 +1058,15 @@
           }
         }
       },
+      "Ports" : {
+        "gatewaymanager": {
+          "PortRange" : {
+            "From" : 65200,
+            "To" : 65535
+          },
+          "IPProtocol" : "all"
+        }
+      },
       "Storage": {
         "default": {
           "storageAccount": {

--- a/services/microsoft.network/resource.ftl
+++ b/services/microsoft.network/resource.ftl
@@ -117,7 +117,7 @@
     [#local destinationPort = "*"]
   [#else]
     [#local destinationPort = isPresent(destinationPortProfile.PortRange)?then(
-      destinationPortProfile.PortRange.From + "-" + destinationPortProfile.PortRange.To,
+      destinationPortProfile.PortRange.From?c + "-" + destinationPortProfile.PortRange.To?c,
       destinationPortProfile.Port)]
   [/#if]
 


### PR DESCRIPTION
Azure has some[ very specific requirements](https://docs.microsoft.com/en-us/azure/application-gateway/configuration-overview#network-security-groups-on-the-application-gateway-subnet) for Application Gateway resources - they require their own subnet and the NSG's associated with that subnet have their own requirements - they require open access between the GatewayManager service tag and the subnet as well as the AzureLoadBalancer service tag.

Currently, there are known problems with the GatewayManager service tag being used within NSG rule definitions - it simply wont work. Rules using this service tag will block access. Application Gateway's validate this access before deployment so their deployment will fail if they use this service tag currently.

The only known work around for the time being is to add rules granting open access to ports 65200-65535 from the Internet to "any" destination. Microsoft have advised that these ports are locked down and access to them is only granted when requested from other Azure infrastructure with valid certificates. They also won't work if you have any non-default outbound NSG rules assigned.

This PR thus moves the ELB subnet out into its own Network Security Group which is then assigned the necessary App Gateway rules. This minimises the impact that these rules may have. When the GatewayManager tag is fixed with App Gateway's, these rules should be updated to instead use the service tag tag instead of using the source of "any". However due to the requirements on no outbound rules, the subnet should remain in its own NSG.

Links: 
- [Azure Network Feedback ticket](https://feedback.azure.com/forums/217313-networking/suggestions/36933709-remove-nsg-validation-from-app-gateway-v2-deployme)
- [Confirmation that GatewayManager service tag is a known issue](https://github.com/MicrosoftDocs/azure-docs/issues/38900)