### PR TITLE
KeyVault SoftDelete in Baseline

### DIFF
--- a/components/baseline/setup.ftl
+++ b/components/baseline/setup.ftl
@@ -328,7 +328,7 @@
           true,
           true,
           true,
-          false,
+          true,
           "default",
           true,
           getNetworkAcls("Deny", keyVaultIpRules, [], "AzureServices")

--- a/services/microsoft.storage/resource.ftl
+++ b/services/microsoft.storage/resource.ftl
@@ -74,7 +74,7 @@
     [#return
         {} +
         attributeIfContent("name", name) +
-        attributeIfTrue("useSubDomainName", useSubDomainName)
+        attributeIfTrue("useSubDomainName", useSubDomainName, useSubDomainName)
     ]
 [/#function]
 


### PR DESCRIPTION
SoftDelete is a property of KeyVault that allows the recovery of deleted items. In order to provision an Application Gateway resource with a certificate stored in KeyVault, the Vault must have SoftDelete enabled.

This PR incorporates that change into the baseline component.

Also fixes an incorrect call to the `attributeifTrue()` function.