### PR TITLE
Fix - GetReference

### DIFF
--- a/deploymentframeworks/arm/output.ftl
+++ b/deploymentframeworks/arm/output.ftl
@@ -179,7 +179,7 @@
                 [#local outputName = formatAttributeId(id, propertySections)]
                 [#local type = attributeValue?is_hash?then("object","string")]
                 [#local typeFull = getAzureResourceProfile(getResourceType(id)).type]
-                [#local value = getReference(id, name, typeFull, attributeType, "", "", attributeValue)]
+                [#local value = getReference(id, name, typeFull, attributeType, "", "", true, attributeValue)]
             [/#if]
 
             [@armOutput

--- a/services/resource.ftl
+++ b/services/resource.ftl
@@ -68,6 +68,7 @@ can be referenced via dot notation. --]
     outputType=REFERENCE_ATTRIBUTE_TYPE
     subscriptionId=""
     resourceGroupName=""
+    fullResource=true
     attributes...]
 
     [#-- get short type - used for apiVersion + conditions --]
@@ -81,6 +82,13 @@ can be referenced via dot notation. --]
     [#-- get long type - used for referencing resources in ARM functions --]
     [#if typeFull == ""]
         [#local typeFull = resourceProfile.type]
+    [/#if]
+
+    [#-- Provide a full resource object or just the properties object --]
+    [#if fullResource]
+        [#local fullOrPartReference = "', 'Full'"]
+    [#else]
+        [#local fullOrPartReference = "'"]
     [/#if]
 
     [#if isPartOfCurrentDeploymentUnit(resourceId)]
@@ -107,7 +115,7 @@ can be referenced via dot notation. --]
                 [#-- return a reference to the specific resources attributes. --]
                 [#-- Example: "[reference(resourceId(resourceType, resourceName), '0000-00-00', 'Full').properties.attribute]" --]
                 [#return
-                    "[reference(resourceId('" + typeFull + "', '" + concatenate(nameSegments, "', '") + "'), '" + apiVersion + "', 'Full')." + (attributes?has_content)?then(attributes?join("."), "") + "]"
+                    "[reference(resourceId('" + typeFull + "', '" + concatenate(nameSegments, "', '") + "'), '" + apiVersion + fullOrPartReference + ")." + (attributes?has_content)?then(attributes?join("."), "") + "]"
                 ]
             [/#if]
         [/#if]
@@ -116,7 +124,7 @@ can be referenced via dot notation. --]
             [#-- return a reference to the specific resources attributes in another Deployment Unit --]
             [#-- Example: "[reference(resourceId(subscriptionId, resourceGroupName, resourceType, resourceName), '0000-00-00', 'Full').properties.attribute]" --]
             [#return
-                "[reference(resourceId('" + subscriptionId + "', '" + resourceGroupName + "', '" + typeFull + "', '" + concatenate(nameSegments, "', '") + "'), '" + apiVersion + "', 'Full')." + (attributes?has_content)?then(attributes?join("."), "") + "]"
+                "[reference(resourceId('" + subscriptionId + "', '" + resourceGroupName + "', '" + typeFull + "', '" + concatenate(nameSegments, "', '") + "'), '" + apiVersion + fullOrPartReference + ")." + (attributes?has_content)?then(attributes?join("."), "") + "]"
             ]
         [#else]
             [#return getExistingReference(
@@ -144,7 +152,9 @@ such an object Id through parent/grandparent Ids/Names --]
     grandChildType=""
     grandChildName=""
     subscriptionId=""
-    resourceGroupName=""]
+    resourceGroupName=""
+    fullResource=false
+    attributes...]
 
     [#local names = [resourceName, childName]]
     [#if grandChildName?has_content]
@@ -163,7 +173,9 @@ such an object Id through parent/grandparent Ids/Names --]
             types?join('/'),
             REFERENCE_ATTRIBUTE_TYPE,
             subscriptionId,
-            resourceGroupName
+            resourceGroupName,
+            fullResource,
+            attributes
         )
     ]
 


### PR DESCRIPTION
By default in the Azure provider currently the `getReferene()` function, if returning a reference() ARM function call, will return a full Resource. This PR updates this to be optional, so you can retrieve just the properties, or the entire object.

Some properties interestingly don't return when "Full" is specified - importantly this includes the "principalId" of a User Assigned Identity as is used in the lb component.